### PR TITLE
update pravega-rust-client for the keycloak auth renew fix

### DIFF
--- a/gst-plugin-pravega/Cargo.lock
+++ b/gst-plugin-pravega/Cargo.lock
@@ -1772,6 +1772,7 @@ dependencies = [
  "async-trait",
  "clap",
  "derive_more",
+ "futures",
  "im",
  "jsonwebtoken",
  "ordered-float 1.1.1",


### PR DESCRIPTION
```
KEYCLOAK_SERVICE_ACCOUNT_FILE="/home/luis/keycloak1.json"
PRAVEGA_CONTROLLER_URI="tls://pravega-controller.kubespray.nautilus-platform-dev.com:443"
PRAVEGA_SCOPE="rungpu"
pravega_client_tls_cert_path="/etc/ssl/certs/ca-certificates.crt"

./scripts/videotestsrc-to-pravega-live.sh
```

test for 1 hour, no issue occurs.