### PR TITLE
Allow overriding the docker base repository

### DIFF
--- a/docker/build-release.sh
+++ b/docker/build-release.sh
@@ -15,9 +15,10 @@ set -ex
 ROOT_DIR=$(readlink -f $(dirname $0)/..)
 GSTREAMER_CHECKOUT=${GSTREAMER_CHECKOUT:-1.18.4}
 RUST_JOBS=${RUST_JOBS:-4}
+DOCKER_REPOSITORY=${DOCKER_REPOSITORY}
 
 # Make sure to always have fresh base image
-#docker pull ubuntu:20.10
+#docker pull ${DOCKER_REPOSITORY}ubuntu:20.10
 pushd ${ROOT_DIR}/docker
 
 docker build -t pravega/gstreamer:${GSTREAMER_CHECKOUT}-dev-with-source \
@@ -36,6 +37,7 @@ docker build -t pravega/gstreamer:${GSTREAMER_CHECKOUT}-dev-with-source \
     --build-arg GST_RTSP_SERVER_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-rtsp-server.git \
     --build-arg GST_RTSP_SERVER_CHECKOUT=${GSTREAMER_CHECKOUT} \
     --build-arg RUST_JOBS=${RUST_JOBS} \
+    --build-arg DOCKER_REPOSITORY=${DOCKER_REPOSITORY} \
     --target dev-with-source \
     -f dev.Dockerfile \
     .
@@ -45,5 +47,6 @@ popd
 docker build -t pravega/gstreamer:pravega-dev \
     --build-arg FROM_IMAGE=pravega/gstreamer:${GSTREAMER_CHECKOUT}-dev-with-source \
     --build-arg RUST_JOBS=${RUST_JOBS} \
+    --build-arg DOCKER_REPOSITORY=${DOCKER_REPOSITORY} \
     -f ${ROOT_DIR}/docker/pravega-dev.Dockerfile ${ROOT_DIR}
 

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -8,7 +8,9 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 
-FROM ubuntu:20.10 as base
+ARG DOCKER_REPOSITORY=""
+
+FROM "${DOCKER_REPOSITORY}ubuntu:20.10" as base
 
 COPY docker/build-gstreamer/install-dependencies /
 

--- a/docker/prod.Dockerfile
+++ b/docker/prod.Dockerfile
@@ -8,9 +8,11 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 
+ARG DOCKER_REPOSITORY=""
+
 FROM pravega/gstreamer:dev-downloaded as dev-downloaded
 
-FROM ubuntu:20.10 as prod-base
+FROM "${DOCKER_REPOSITORY}ubuntu:20.10" as prod-base
 
 RUN \
     apt-get update && \


### PR DESCRIPTION
I'm not sure if this is the best way.

Internally, our build servers frequently get `toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit` because from the outside world, they look like the same IP. We work around that by having a private registry and get containers to build by pulling their base images from that.

There are two ways to support this:

- Overwrite/supply to dockerfile (w/ arg)
- Change the daemon.json for docker to have our private registry as a mirror

I don't particular like the latter as that introduces a hard to notice side effect.. Say private repo has a base image that when builds it works, but the public dockerhub image when used as a base image fails. This would cause an issue where devs locally build fail but the build server works.