### PR TITLE
Fix deadlock and incorrect seeking behavior in pravegasrc

### DIFF
--- a/apps/src/bin/rtsp-camera-simulator.rs
+++ b/apps/src/bin/rtsp-camera-simulator.rs
@@ -9,7 +9,9 @@
 //
 
 // Simulate an RTSP camera.
-// Based on gstreamer-rs/examples/src/bin/rtsp-server.rs and rtsp-server-record.rs.
+// Based on:
+//   - https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/-/blob/master/examples/src/bin/rtsp-server.rs
+//   - https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/-/blob/master/examples/src/bin/rtsp-server-record.rs
 
 use anyhow::Error;
 use clap::Clap;

--- a/gst-plugin-pravega/src/counting_writer.rs
+++ b/gst-plugin-pravega/src/counting_writer.rs
@@ -1,0 +1,63 @@
+//
+// Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+
+use std::io::{Write, Result, Seek, SeekFrom};
+
+/// Write adaptor that tracks the current offset so it can be returned without seeking the inner writer.
+#[derive(Debug)]
+pub struct CountingWriter<T: Write + Seek> {
+    inner: T,
+    offset: u64,
+}
+
+impl<T: Write + Seek> CountingWriter<T> {
+    pub fn new(mut writer: T) -> Result<CountingWriter<T>> {
+        let offset = writer.seek(SeekFrom::Current(0))?;
+        let writer = CountingWriter {
+            inner: writer,
+            offset
+        };
+        Ok(writer)
+    }
+
+    /// Gets a mutable reference to the underlying writer.
+    ///
+    /// Care should be taken to avoid modifying the internal I/O state of the
+    /// underlying writer as doing so may corrupt the offset.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl<T: Write + Seek> Write for CountingWriter<T> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        let result = self.inner.write(buf);
+        if let Ok(written) = result {
+            self.offset += written as u64;
+        }
+        result
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.inner.flush()
+    }
+}
+
+impl<T: Write + Seek> Seek  for CountingWriter<T> {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        match pos {
+            SeekFrom::Current(0) => Ok(self.offset),
+            _ => {
+                self.offset = self.inner.seek(pos)?;
+                Ok(self.offset)
+            }
+        }
+    }
+}

--- a/gst-plugin-pravega/src/lib.rs
+++ b/gst-plugin-pravega/src/lib.rs
@@ -12,6 +12,7 @@ mod numeric;
 mod pravegasink;
 mod pravegasrc;
 mod seekable_take;
+pub mod utils;
 
 fn plugin_init(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
     pravegasink::register(plugin)?;

--- a/gst-plugin-pravega/src/lib.rs
+++ b/gst-plugin-pravega/src/lib.rs
@@ -8,6 +8,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 //
 
+mod counting_reader;
 mod counting_writer;
 mod numeric;
 mod pravegasink;

--- a/gst-plugin-pravega/src/lib.rs
+++ b/gst-plugin-pravega/src/lib.rs
@@ -8,9 +8,11 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 //
 
+mod counting_writer;
 mod numeric;
 mod pravegasink;
 mod pravegasrc;
+mod seekable_byte_stream_writer;
 mod seekable_take;
 pub mod utils;
 

--- a/gst-plugin-pravega/src/pravegasink/imp.rs
+++ b/gst-plugin-pravega/src/pravegasink/imp.rs
@@ -58,14 +58,14 @@ pub enum TimestampMode {
     #[genum(
         name = "Input buffer timestamps are nanoseconds \
                 since the NTP epoch 1900-01-01 00:00:00 UTC, not including leap seconds. \
-                Use this for rtspsrc (ntp-sync=true ntp-time-source=running-time).",
+                Use this for buffers from rtspsrc (ntp-sync=true ntp-time-source=running-time).",
         nick = "ntp"
     )]
     Ntp = 1,
     #[genum(
         name = "Input buffer timestamps are nanoseconds \
                 since 1970-01-01 00:00:00 TAI International Atomic Time, including leap seconds. \
-                Use this for pravegasrc (start-pts-at-zero=false).",
+                Use this for buffers from pravegasrc (start-pts-at-zero=false).",
         nick = "tai"
     )]
     Tai = 2,

--- a/gst-plugin-pravega/src/pravegasink/imp.rs
+++ b/gst-plugin-pravega/src/pravegasink/imp.rs
@@ -447,123 +447,125 @@ impl ElementImpl for PravegaSink {
 impl BaseSinkImpl for PravegaSink {
     fn start(&self, element: &Self::Type) -> Result<(), gst::ErrorMessage> {
         gst_debug!(CAT, obj: element, "start: BEGIN");
+        let result = (|| {
+            let mut state = self.state.lock().unwrap();
+            if let State::Started { .. } = *state {
+                unreachable!("PravegaSink already started");
+            }
 
-        let mut state = self.state.lock().unwrap();
-        if let State::Started { .. } = *state {
-            unreachable!("PravegaSink already started");
-        }
-
-        let settings = self.settings.lock().unwrap();
-        gst_info!(CAT, obj: element, "start: index_min_nanos={}, index_max_nanos={}", settings.index_min_nanos, settings.index_max_nanos);
-        if !(settings.index_min_nanos <= settings.index_max_nanos) {
-            return Err(gst::error_msg!(gst::ResourceError::Settings,
-                ["{} must be <= {}", PROPERTY_NAME_INDEX_MIN_SEC, PROPERTY_NAME_INDEX_MAX_SEC]))
-        };
-        let scope_name: String = settings.scope.clone().ok_or_else(|| {
-            gst::error_msg!(gst::ResourceError::Settings, ["Scope is not defined"])
-        })?;
-        let stream_name = settings.stream.clone().ok_or_else(|| {
-            gst::error_msg!(gst::ResourceError::Settings, ["Stream is not defined"])
-        })?;
-        let index_stream_name = get_index_stream_name(&stream_name);
-        let scope = Scope::from(scope_name);
-        let stream = Stream::from(stream_name);
-        let index_stream = Stream::from(index_stream_name);
-        gst_info!(CAT, obj: element, "start: scope={}, stream={}, index_stream={}", scope, stream, index_stream);
-        gst_info!(CAT, obj: element, "start: timestamp_mode={:?}", settings.timestamp_mode);
-
-        let controller = settings.controller.clone().ok_or_else(|| {
-            gst::error_msg!(gst::ResourceError::Settings, ["Controller is not defined"])
-        })?;
-        gst_info!(CAT, obj: element, "start: controller={}", controller);
-        let keycloak_file = settings.keycloak_file.clone();
-        gst_info!(CAT, obj: element, "start: keycloak_file={:?}", keycloak_file);
-        let config = utils::create_client_config(controller, keycloak_file).map_err(|error| {
-            gst::error_msg!(gst::ResourceError::Settings, ["Failed to create Pravega client config: {}", error])
-        })?;
-        gst_debug!(CAT, obj: element, "start: config={:?}", config);
-        gst_info!(CAT, obj: element, "start: controller_uri={}:{}", config.controller_uri.domain_name(), config.controller_uri.port());
-        gst_info!(CAT, obj: element, "start: is_tls_enabled={}", config.is_tls_enabled);
-        gst_info!(CAT, obj: element, "start: is_auth_enabled={}", config.is_auth_enabled);
-
-        let client_factory = ClientFactory::new(config);
-        let controller_client = client_factory.get_controller_client();
-        let runtime = client_factory.get_runtime();
-
-        // Create scope.
-        gst_info!(CAT, obj: element, "start: allow_create_scope={}", settings.allow_create_scope);
-        if settings.allow_create_scope {
-            runtime.block_on(controller_client.create_scope(&scope)).map_err(|error| {
-                gst::error_msg!(gst::ResourceError::Settings, ["Failed to create Pravega scope: {:?}", error])
+            let settings = self.settings.lock().unwrap();
+            gst_info!(CAT, obj: element, "start: index_min_nanos={}, index_max_nanos={}", settings.index_min_nanos, settings.index_max_nanos);
+            if !(settings.index_min_nanos <= settings.index_max_nanos) {
+                return Err(gst::error_msg!(gst::ResourceError::Settings,
+                    ["{} must be <= {}", PROPERTY_NAME_INDEX_MIN_SEC, PROPERTY_NAME_INDEX_MAX_SEC]))
+            };
+            let scope_name: String = settings.scope.clone().ok_or_else(|| {
+                gst::error_msg!(gst::ResourceError::Settings, ["Scope is not defined"])
             })?;
-        }
+            let stream_name = settings.stream.clone().ok_or_else(|| {
+                gst::error_msg!(gst::ResourceError::Settings, ["Stream is not defined"])
+            })?;
+            let index_stream_name = get_index_stream_name(&stream_name);
+            let scope = Scope::from(scope_name);
+            let stream = Stream::from(stream_name);
+            let index_stream = Stream::from(index_stream_name);
+            gst_info!(CAT, obj: element, "start: scope={}, stream={}, index_stream={}", scope, stream, index_stream);
+            gst_info!(CAT, obj: element, "start: timestamp_mode={:?}", settings.timestamp_mode);
 
-        // Create data stream.
-        let stream_config = StreamConfiguration {
-            scoped_stream: ScopedStream {
+            let controller = settings.controller.clone().ok_or_else(|| {
+                gst::error_msg!(gst::ResourceError::Settings, ["Controller is not defined"])
+            })?;
+            gst_info!(CAT, obj: element, "start: controller={}", controller);
+            let keycloak_file = settings.keycloak_file.clone();
+            gst_info!(CAT, obj: element, "start: keycloak_file={:?}", keycloak_file);
+            let config = utils::create_client_config(controller, keycloak_file).map_err(|error| {
+                gst::error_msg!(gst::ResourceError::Settings, ["Failed to create Pravega client config: {}", error])
+            })?;
+            gst_debug!(CAT, obj: element, "start: config={:?}", config);
+            gst_info!(CAT, obj: element, "start: controller_uri={}:{}", config.controller_uri.domain_name(), config.controller_uri.port());
+            gst_info!(CAT, obj: element, "start: is_tls_enabled={}", config.is_tls_enabled);
+            gst_info!(CAT, obj: element, "start: is_auth_enabled={}", config.is_auth_enabled);
+
+            let client_factory = ClientFactory::new(config);
+            let controller_client = client_factory.get_controller_client();
+            let runtime = client_factory.get_runtime();
+
+            // Create scope.
+            gst_info!(CAT, obj: element, "start: allow_create_scope={}", settings.allow_create_scope);
+            if settings.allow_create_scope {
+                runtime.block_on(controller_client.create_scope(&scope)).map_err(|error| {
+                    gst::error_msg!(gst::ResourceError::Settings, ["Failed to create Pravega scope: {:?}", error])
+                })?;
+            }
+
+            // Create data stream.
+            let stream_config = StreamConfiguration {
+                scoped_stream: ScopedStream {
+                    scope: scope.clone(),
+                    stream: stream.clone(),
+                },
+                scaling: Scaling {
+                    scale_type: ScaleType::FixedNumSegments,
+                    min_num_segments: 1,
+                    ..Default::default()
+                },
+                retention: Default::default(),
+            };
+            runtime.block_on(controller_client.create_stream(&stream_config)).map_err(|error| {
+                gst::error_msg!(gst::ResourceError::Settings, ["Failed to create Pravega data stream: {:?}", error])
+            })?;
+
+            // Create index stream.
+            let index_stream_config = StreamConfiguration {
+                scoped_stream: ScopedStream {
+                    scope: scope.clone(),
+                    stream: index_stream.clone(),
+                },
+                scaling: Scaling {
+                    scale_type: ScaleType::FixedNumSegments,
+                    min_num_segments: 1,
+                    ..Default::default()
+                },
+                retention: Default::default(),
+            };
+            runtime.block_on(controller_client.create_stream(&index_stream_config)).map_err(|error| {
+                gst::error_msg!(gst::ResourceError::Settings, ["Failed to create Pravega index stream: {:?}", error])
+            })?;
+
+            let scoped_segment = ScopedSegment {
                 scope: scope.clone(),
                 stream: stream.clone(),
-            },
-            scaling: Scaling {
-                scale_type: ScaleType::FixedNumSegments,
-                min_num_segments: 1,
-                ..Default::default()
-            },
-            retention: Default::default(),
-        };
-        runtime.block_on(controller_client.create_stream(&stream_config)).map_err(|error| {
-            gst::error_msg!(gst::ResourceError::Settings, ["Failed to create Pravega data stream: {:?}", error])
-        })?;
+                segment: Segment::from(0),
+            };
+            let mut writer = client_factory.create_byte_stream_writer(scoped_segment);
+            gst_info!(CAT, obj: element, "start: Opened Pravega writer for data");
+            writer.seek_to_tail();
 
-        // Create index stream.
-        let index_stream_config = StreamConfiguration {
-            scoped_stream: ScopedStream {
+            let index_scoped_segment = ScopedSegment {
                 scope: scope.clone(),
                 stream: index_stream.clone(),
-            },
-            scaling: Scaling {
-                scale_type: ScaleType::FixedNumSegments,
-                min_num_segments: 1,
-                ..Default::default()
-            },
-            retention: Default::default(),
-        };
-        runtime.block_on(controller_client.create_stream(&index_stream_config)).map_err(|error| {
-            gst::error_msg!(gst::ResourceError::Settings, ["Failed to create Pravega index stream: {:?}", error])
-        })?;
+                segment: Segment::from(0),
+            };
+            let mut index_writer = client_factory.create_byte_stream_writer(index_scoped_segment);
+            gst_info!(CAT, obj: element, "start: Opened Pravega writer for index");
+            index_writer.seek_to_tail();
 
-        let scoped_segment = ScopedSegment {
-            scope: scope.clone(),
-            stream: stream.clone(),
-            segment: Segment::from(0),
-        };
-        let mut writer = client_factory.create_byte_stream_writer(scoped_segment);
-        gst_info!(CAT, obj: element, "start: Opened Pravega writer for data");
-        writer.seek_to_tail();
+            gst_info!(CAT, obj: element, "start: Buffer size is {}", settings.buffer_size);
+            let buf_writer = BufWriter::with_capacity(settings.buffer_size, writer);
 
-        let index_scoped_segment = ScopedSegment {
-            scope: scope.clone(),
-            stream: index_stream.clone(),
-            segment: Segment::from(0),
-        };
-        let mut index_writer = client_factory.create_byte_stream_writer(index_scoped_segment);
-        gst_info!(CAT, obj: element, "start: Opened Pravega writer for index");
-        index_writer.seek_to_tail();
-
-        gst_info!(CAT, obj: element, "start: Buffer size is {}", settings.buffer_size);
-        let buf_writer = BufWriter::with_capacity(settings.buffer_size, writer);
-
-        *state = State::Started {
-            client_factory,
-            writer: buf_writer,
-            index_writer,
-            last_index_time: PravegaTimestamp::NONE,
-            final_timestamp: PravegaTimestamp::NONE,
-            final_offset: None,
-        };
-        gst_info!(CAT, obj: element, "start: Started");
-        gst_debug!(CAT, obj: element, "start: END");
-        Ok(())
+            *state = State::Started {
+                client_factory,
+                writer: buf_writer,
+                index_writer,
+                last_index_time: PravegaTimestamp::NONE,
+                final_timestamp: PravegaTimestamp::NONE,
+                final_offset: None,
+            };
+            gst_info!(CAT, obj: element, "start: Started");
+            Ok(())
+        })();
+        gst_debug!(CAT, obj: element, "start: END; result={:?}", result);
+        result
     }
 
     fn render(
@@ -572,265 +574,270 @@ impl BaseSinkImpl for PravegaSink {
         buffer: &gst::Buffer,
     ) -> Result<gst::FlowSuccess, gst::FlowError> {
 
-        gst_trace!(CAT, obj: element, "render: Rendering {:?}", buffer);
-
-        let mut state = self.state.lock().unwrap();
-        let (writer,
-            index_writer,
-            last_index_time,
-            final_timestamp,
-            final_offset) = match *state {
-            State::Started {
-                ref mut writer,
-                ref mut index_writer,
-                ref mut last_index_time,
-                ref mut final_timestamp,
-                ref mut final_offset,
-                ..
-            } => (writer,
+        gst_trace!(CAT, obj: element, "render: BEGIN: Rendering {:?}", buffer);
+        let result = (|| {
+            let mut state = self.state.lock().unwrap();
+            let (writer,
                 index_writer,
                 last_index_time,
                 final_timestamp,
-                final_offset),
-            State::Stopped => {
-                gst::element_error!(element, gst::CoreError::Failed, ["Not started yet"]);
-                return Err(gst::FlowError::Error);
-            }
-        };
-
-        let pts = buffer.get_pts();
-        let duration = buffer.get_duration();
-
-        let map = buffer.map_readable().map_err(|_| {
-            gst::element_error!(element, gst::CoreError::Failed, ["Failed to map buffer"]);
-            gst::FlowError::Error
-        })?;
-        let payload = map.as_ref();
-
-        let (timestamp_mode, index_min_nanos, index_max_nanos) = {
-            let settings = self.settings.lock().unwrap();
-            (settings.timestamp_mode, settings.index_min_nanos, settings.index_max_nanos)
-        };
-
-        let timestamp = match timestamp_mode {
-            TimestampMode::RealtimeClock => {
-                // pts is time between beginning of play and beginning of this buffer.
-                // base_time is the value of the pipeline clock (time since Unix epoch) at the beginning of play.
-                PravegaTimestamp::from_unix_nanoseconds((element.get_base_time() + pts).nseconds())
-            },
-            TimestampMode::Ntp => {
-                // When receiving from rtspsrc (ntp-sync=true ntp-time-source=running-time),
-                // pts will be the number of nanoseconds since the NTP epoch 1900-01-01 00:00:00 UTC
-                // of when the video frame was observed by the camera.
-                // Note: base_time is the value of the pipeline clock at the beginning of play. It is ignored.
-                PravegaTimestamp::from_ntp_nanoseconds(pts.nseconds())
-            },
-            TimestampMode::Tai => {
-                PravegaTimestamp::from_nanoseconds(pts.nseconds())
-            }
-        };
-
-        gst_log!(CAT, obj: element, "render: timestamp={:?}, pts={}, base_time={}, duration={}, size={}",
-            timestamp, pts, element.get_base_time(), buffer.get_duration(), buffer.get_size());
-
-        // We only want to include key frames (non-delta units) in the index.
-        // However, if no key frame has been received in a while, force an index record.
-        // This is required for nvv4l2h264enc because it identifies all buffers as DELTA_UNIT.
-        let buffer_flags = buffer.get_flags();
-        let is_delta_unit = buffer_flags.contains(gst::BufferFlags::DELTA_UNIT);
-        let random_access = !is_delta_unit;
-        let include_in_index = match timestamp.nanoseconds() {
-            Some(timestamp) => {
-                match last_index_time.nanoseconds() {
-                    Some(last_index_time) => {
-                        let interval_sec = u64_to_i64_saturating_sub(timestamp, last_index_time) as f64 * 1e-9;
-                        if is_delta_unit {
-                            if timestamp > last_index_time + index_max_nanos {
-                                gst_fixme!(CAT, obj: element,
-                                    "render: Forcing index record at delta unit because no key frame has been received for {} sec", interval_sec);
-                                true
-                            } else {
-                                false
-                            }
-                        } else {
-                            // We are at a key frame.
-                            if timestamp < last_index_time + index_min_nanos {
-                                gst_debug!(CAT, obj: element,
-                                    "render: Skipping creation of index record because an index record was created {} sec ago", interval_sec);
-                                false
-                            } else {
-                                gst_debug!(CAT, obj: element,
-                                    "render: Creating index record at key frame; last index record was created {} sec ago", interval_sec);
-                                true
-                            }
-                        }
-                    },
-                    None => {
-                        // An index record has not been written by this element yet.
-                        true
-                    },
+                final_offset) = match *state {
+                State::Started {
+                    ref mut writer,
+                    ref mut index_writer,
+                    ref mut last_index_time,
+                    ref mut final_timestamp,
+                    ref mut final_offset,
+                    ..
+                } => (writer,
+                    index_writer,
+                    last_index_time,
+                    final_timestamp,
+                    final_offset),
+                State::Stopped => {
+                    gst::element_error!(element, gst::CoreError::Failed, ["Not started yet"]);
+                    return Err(gst::FlowError::Error);
                 }
-            },
-            None => {
-                // Buffer has an invalid timestamp.
-                false
-            },
-        };
+            };
 
-        // Per the index constraints defined in index.rs, if we are writing an index record now,
-        // we must flush any data writes prior to this buffer, so that reads do not block waiting on this writer.
-        let flush = include_in_index;
-        if flush {
-            writer.flush().map_err(|error| {
-                gst::element_error!(element, gst::CoreError::Failed, ["Failed to flush Pravega data stream: {}", error]);
+            let pts = buffer.get_pts();
+            let duration = buffer.get_duration();
+
+            let map = buffer.map_readable().map_err(|_| {
+                gst::element_error!(element, gst::CoreError::Failed, ["Failed to map buffer"]);
                 gst::FlowError::Error
             })?;
-        }
+            let payload = map.as_ref();
 
-        // If we are writing an index record now, get the current offset.
-        // This offset will be used in the index.
-        // Since we are using a BufWriter, it is critical that it has been flushed prior to this.
-        let stream_position0 = if include_in_index {
-            assert!(flush);
-            Some(writer.get_mut().current_write_offset() as u64)
-        } else {
-            None
-        };
+            let (timestamp_mode, index_min_nanos, index_max_nanos) = {
+                let settings = self.settings.lock().unwrap();
+                (settings.timestamp_mode, settings.index_min_nanos, settings.index_max_nanos)
+            };
 
-        // Record a discontinuity if upstream has indicated one or if this will be
-        // the first index record emitted from this instance.
-        let discontinuity = buffer_flags.contains(gst::BufferFlags::DISCONT)
-            || buffer_flags.contains(gst::BufferFlags::RESYNC)
-            || (include_in_index && last_index_time.nanoseconds().is_none());
+            let timestamp = match timestamp_mode {
+                TimestampMode::RealtimeClock => {
+                    // pts is time between beginning of play and beginning of this buffer.
+                    // base_time is the value of the pipeline clock (time since Unix epoch) at the beginning of play.
+                    PravegaTimestamp::from_unix_nanoseconds((element.get_base_time() + pts).nseconds())
+                },
+                TimestampMode::Ntp => {
+                    // When receiving from rtspsrc (ntp-sync=true ntp-time-source=running-time),
+                    // pts will be the number of nanoseconds since the NTP epoch 1900-01-01 00:00:00 UTC
+                    // of when the video frame was observed by the camera.
+                    // Note: base_time is the value of the pipeline clock at the beginning of play. It is ignored.
+                    PravegaTimestamp::from_ntp_nanoseconds(pts.nseconds())
+                },
+                TimestampMode::Tai => {
+                    PravegaTimestamp::from_nanoseconds(pts.nseconds())
+                }
+            };
 
-        // Write index record.
-        // We write the index record before the buffer so that any readers blocked on reading the
-        // index will unblock as soon as possible.
-        if include_in_index {
-            let index_record = IndexRecord::new(timestamp, stream_position0.unwrap(),
-                random_access, discontinuity);
-            let mut index_record_writer = IndexRecordWriter::new();
-            index_record_writer.write(&index_record, index_writer).map_err(|err| {
+            gst_log!(CAT, obj: element, "render: timestamp={:?}, pts={}, base_time={}, duration={}, size={}",
+                timestamp, pts, element.get_base_time(), buffer.get_duration(), buffer.get_size());
+
+            // We only want to include key frames (non-delta units) in the index.
+            // However, if no key frame has been received in a while, force an index record.
+            // This is required for nvv4l2h264enc because it identifies all buffers as DELTA_UNIT.
+            let buffer_flags = buffer.get_flags();
+            let is_delta_unit = buffer_flags.contains(gst::BufferFlags::DELTA_UNIT);
+            let random_access = !is_delta_unit;
+            let include_in_index = match timestamp.nanoseconds() {
+                Some(timestamp) => {
+                    match last_index_time.nanoseconds() {
+                        Some(last_index_time) => {
+                            let interval_sec = u64_to_i64_saturating_sub(timestamp, last_index_time) as f64 * 1e-9;
+                            if is_delta_unit {
+                                if timestamp > last_index_time + index_max_nanos {
+                                    gst_fixme!(CAT, obj: element,
+                                        "render: Forcing index record at delta unit because no key frame has been received for {} sec", interval_sec);
+                                    true
+                                } else {
+                                    false
+                                }
+                            } else {
+                                // We are at a key frame.
+                                if timestamp < last_index_time + index_min_nanos {
+                                    gst_debug!(CAT, obj: element,
+                                        "render: Skipping creation of index record because an index record was created {} sec ago", interval_sec);
+                                    false
+                                } else {
+                                    gst_debug!(CAT, obj: element,
+                                        "render: Creating index record at key frame; last index record was created {} sec ago", interval_sec);
+                                    true
+                                }
+                            }
+                        },
+                        None => {
+                            // An index record has not been written by this element yet.
+                            true
+                        },
+                    }
+                },
+                None => {
+                    // Buffer has an invalid timestamp.
+                    false
+                },
+            };
+
+            // Per the index constraints defined in index.rs, if we are writing an index record now,
+            // we must flush any data writes prior to this buffer, so that reads do not block waiting on this writer.
+            let flush = include_in_index;
+            if flush {
+                writer.flush().map_err(|error| {
+                    gst::element_error!(element, gst::CoreError::Failed, ["Failed to flush Pravega data stream: {}", error]);
+                    gst::FlowError::Error
+                })?;
+            }
+
+            // If we are writing an index record now, get the current offset.
+            // This offset will be used in the index.
+            // Since we are using a BufWriter, it is critical that it has been flushed prior to this.
+            let stream_position0 = if include_in_index {
+                assert!(flush);
+                Some(writer.get_mut().current_write_offset() as u64)
+            } else {
+                None
+            };
+
+            // Record a discontinuity if upstream has indicated one or if this will be
+            // the first index record emitted from this instance.
+            let discontinuity = buffer_flags.contains(gst::BufferFlags::DISCONT)
+                || buffer_flags.contains(gst::BufferFlags::RESYNC)
+                || (include_in_index && last_index_time.nanoseconds().is_none());
+
+            // Write index record.
+            // We write the index record before the buffer so that any readers blocked on reading the
+            // index will unblock as soon as possible.
+            if include_in_index {
+                let index_record = IndexRecord::new(timestamp, stream_position0.unwrap(),
+                    random_access, discontinuity);
+                let mut index_record_writer = IndexRecordWriter::new();
+                index_record_writer.write(&index_record, index_writer).map_err(|err| {
+                    gst::element_error!(
+                        element,
+                        gst::ResourceError::Write,
+                        ["Failed to write index: {}", err]
+                    );
+                    gst::FlowError::Error
+                })?;
+                gst_debug!(CAT, obj: element, "render: Wrote index record {:?}", index_record);
+                *last_index_time = timestamp;
+            }
+
+            // Write buffer to Pravega byte stream.
+            let event = EventWithHeader::new(payload, timestamp,
+                include_in_index, random_access, discontinuity);
+            let mut event_writer = EventWriter::new();
+            event_writer.write(&event, writer).map_err(|err| {
                 gst::element_error!(
                     element,
                     gst::ResourceError::Write,
-                    ["Failed to write index: {}", err]
+                    ["Failed to write buffer: {}", err]
                 );
                 gst::FlowError::Error
             })?;
-            gst_debug!(CAT, obj: element, "render: Wrote index record {:?}", index_record);
-            *last_index_time = timestamp;
-        }
 
-        // Write buffer to Pravega byte stream.
-        let event = EventWithHeader::new(payload, timestamp,
-            include_in_index, random_access, discontinuity);
-        let mut event_writer = EventWriter::new();
-        event_writer.write(&event, writer).map_err(|err| {
-            gst::element_error!(
-                element,
-                gst::ResourceError::Write,
-                ["Failed to write buffer: {}", err]
-            );
-            gst::FlowError::Error
-        })?;
+            // Flush after writing if the buffer contains the SYNC_AFTER flag. This is normally not used.
+            let sync_after = buffer_flags.contains(gst::BufferFlags::SYNC_AFTER);
+            if sync_after {
+                writer.flush().map_err(|error| {
+                    gst::element_error!(element, gst::CoreError::Failed, ["Failed to flush Pravega data stream: {}", error]);
+                    gst::FlowError::Error
+                })?;
+                index_writer.flush().map_err(|error| {
+                    gst::element_error!(element, gst::CoreError::Failed, ["Failed to flush Pravega index stream: {}", error]);
+                    gst::FlowError::Error
+                })?;
+                gst_debug!(CAT, obj: element, "render: Streams flushed because SYNC_AFTER flag was set");
+            }
 
-        // Flush after writing if the buffer contains the SYNC_AFTER flag. This is normally not used.
-        let sync_after = buffer_flags.contains(gst::BufferFlags::SYNC_AFTER);
-        if sync_after {
-            writer.flush().map_err(|error| {
-                gst::element_error!(element, gst::CoreError::Failed, ["Failed to flush Pravega data stream: {}", error]);
-                gst::FlowError::Error
-            })?;
-            index_writer.flush().map_err(|error| {
-                gst::element_error!(element, gst::CoreError::Failed, ["Failed to flush Pravega index stream: {}", error]);
-                gst::FlowError::Error
-            })?;
-            gst_debug!(CAT, obj: element, "render: Streams flushed because SYNC_AFTER flag was set");
-        }
+            // Maintain values that may be written to the index on end-of-stream.
+            // Per the index constraints defined in index.rs, the timestamp in the index record must
+            // be strictly greater than the timestamp in the data stream.
+            // If duration of the buffer is reported as 0, we record it as if it had a 1 nanosecond duration.
+            let duration = cmp::max(1, duration.nanoseconds().unwrap_or_default());
+            // we must flush any data writes prior to this buffer, so that reads do not block waiting on this writer.
+            *final_timestamp = PravegaTimestamp::from_nanoseconds(
+                timestamp.nanoseconds().map(|t| t + duration));
+            *final_offset = Some(writer.get_mut().current_write_offset() as u64);
 
-        // Maintain values that may be written to the index on end-of-stream.
-        // Per the index constraints defined in index.rs, the timestamp in the index record must
-        // be strictly greater than the timestamp in the data stream.
-        // If duration of the buffer is reported as 0, we record it as if it had a 1 nanosecond duration.
-        let duration = cmp::max(1, duration.nanoseconds().unwrap_or_default());
-        // we must flush any data writes prior to this buffer, so that reads do not block waiting on this writer.
-        *final_timestamp = PravegaTimestamp::from_nanoseconds(
-            timestamp.nanoseconds().map(|t| t + duration));
-        *final_offset = Some(writer.get_mut().current_write_offset() as u64);
-
-        gst_trace!(CAT, obj: element, "render: END");
-        Ok(gst::FlowSuccess::Ok)
+            Ok(gst::FlowSuccess::Ok)
+        })();
+        gst_trace!(CAT, obj: element, "render: END: result={:?}", result);
+        result
     }
 
     fn stop(&self, element: &Self::Type) -> Result<(), gst::ErrorMessage> {
-        gst_info!(CAT, obj: element, "stop: Stopping");
-        let seal = {
-            let settings = self.settings.lock().unwrap();
-            settings.seal
-        };
+        gst_info!(CAT, obj: element, "stop: BEGIN");
+        let result = (|| {
+            let seal = {
+                let settings = self.settings.lock().unwrap();
+                settings.seal
+            };
 
-        let mut state = self.state.lock().unwrap();
-        let (writer,
-            index_writer,
-            client_factory,
-            final_timestamp,
-            final_offset) = match *state {
-            State::Started {
-                ref mut writer,
-                ref mut index_writer,
-                ref mut client_factory,
-                ref mut final_timestamp,
-                ref mut final_offset,
-                ..
-            } => (writer,
+            let mut state = self.state.lock().unwrap();
+            let (writer,
                 index_writer,
                 client_factory,
                 final_timestamp,
-                final_offset),
-            State::Stopped => {
-                return Err(gst::error_msg!(
-                    gst::ResourceError::Settings,
-                    ["PravegaSink not started"]
-                ));
+                final_offset) = match *state {
+                State::Started {
+                    ref mut writer,
+                    ref mut index_writer,
+                    ref mut client_factory,
+                    ref mut final_timestamp,
+                    ref mut final_offset,
+                    ..
+                } => (writer,
+                    index_writer,
+                    client_factory,
+                    final_timestamp,
+                    final_offset),
+                State::Stopped => {
+                    return Err(gst::error_msg!(
+                        gst::ResourceError::Settings,
+                        ["PravegaSink not started"]
+                    ));
+                }
+            };
+
+            writer.flush().map_err(|error| {
+                gst::error_msg!(gst::ResourceError::Write, ["Failed to flush Pravega data stream: {}", error])
+            })?;
+
+            // Write final index record.
+            // The timestamp will be the the buffer timestamp + duration of the final buffer.
+            // The offset will be current write position.
+            if let Some(final_offset) = *final_offset {
+                let index_record = IndexRecord::new(*final_timestamp, final_offset,
+                    false, false);
+                let mut index_record_writer = IndexRecordWriter::new();
+                index_record_writer.write(&index_record, index_writer).map_err(|error| {
+                    gst::error_msg!(gst::ResourceError::Write, ["Failed to write Pravega index stream: {}", error])
+                })?;
+                gst_info!(CAT, obj: element, "stop: Wrote final index record {:?}", index_record);
             }
-        };
 
-        writer.flush().map_err(|error| {
-            gst::error_msg!(gst::ResourceError::Write, ["Failed to flush Pravega data stream: {}", error])
-        })?;
-
-        // Write final index record.
-        // The timestamp will be the the buffer timestamp + duration of the final buffer.
-        // The offset will be current write position.
-        if let Some(final_offset) = *final_offset {
-            let index_record = IndexRecord::new(*final_timestamp, final_offset,
-                false, false);
-            let mut index_record_writer = IndexRecordWriter::new();
-            index_record_writer.write(&index_record, index_writer).map_err(|error| {
-                gst::error_msg!(gst::ResourceError::Write, ["Failed to write Pravega index stream: {}", error])
+            index_writer.flush().map_err(|error| {
+                gst::error_msg!(gst::ResourceError::Write, ["Failed to flush Pravega index stream: {}", error])
             })?;
-            gst_info!(CAT, obj: element, "stop: Wrote final index record {:?}", index_record);
-        }
 
-        index_writer.flush().map_err(|error| {
-            gst::error_msg!(gst::ResourceError::Write, ["Failed to flush Pravega index stream: {}", error])
-        })?;
+            if seal {
+                gst_info!(CAT, obj: element, "stop: Sealing streams");
+                let writer = writer.get_mut();
+                client_factory.get_runtime().block_on(writer.seal()).map_err(|error| {
+                    gst::error_msg!(gst::ResourceError::Write, ["Failed to seal Pravega data stream: {}", error])
+                })?;
+                client_factory.get_runtime().block_on(index_writer.seal()).map_err(|error| {
+                    gst::error_msg!(gst::ResourceError::Write, ["Failed to seal Pravega index stream: {}", error])
+                })?;
+                gst_info!(CAT, obj: element, "stop: Streams sealed");
+            }
 
-        if seal {
-            gst_info!(CAT, obj: element, "stop: Sealing streams");
-            let writer = writer.get_mut();
-            client_factory.get_runtime().block_on(writer.seal()).map_err(|error| {
-                gst::error_msg!(gst::ResourceError::Write, ["Failed to seal Pravega data stream: {}", error])
-            })?;
-            client_factory.get_runtime().block_on(index_writer.seal()).map_err(|error| {
-                gst::error_msg!(gst::ResourceError::Write, ["Failed to seal Pravega index stream: {}", error])
-            })?;
-            gst_info!(CAT, obj: element, "stop: Streams sealed");
-        }
-
-        *state = State::Stopped;
-        gst_info!(CAT, obj: element, "stop: Stopped");
-        Ok(())
+            *state = State::Stopped;
+            Ok(())
+        })();
+        gst_info!(CAT, obj: element, "stop: END: result={:?}", result);
+        result
     }
 }

--- a/gst-plugin-pravega/src/pravegasink/imp.rs
+++ b/gst-plugin-pravega/src/pravegasink/imp.rs
@@ -8,8 +8,9 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 //
 
-// A sink that writes GStreamer buffers along with timestamps.
-// Each GstBuffer is framed.
+// A sink that writes GStreamer buffers to a Pravega stream.
+// Based on:
+//   - https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/tree/master/generic/file/src/filesink
 
 use glib::subclass::prelude::*;
 use gst::prelude::*;

--- a/gst-plugin-pravega/src/pravegasink/imp.rs
+++ b/gst-plugin-pravega/src/pravegasink/imp.rs
@@ -15,7 +15,7 @@
 use glib::subclass::prelude::*;
 use gst::prelude::*;
 use gst::subclass::prelude::*;
-use gst::{gst_debug, gst_error, gst_fixme, gst_info, gst_log, gst_trace};
+use gst::{gst_debug, gst_error, gst_fixme, gst_info, gst_log, gst_trace, gst_memdump};
 use gst_base::subclass::prelude::*;
 
 use std::cmp;
@@ -727,6 +727,7 @@ impl BaseSinkImpl for PravegaSink {
             // Write buffer to Pravega byte stream.
             let event = EventWithHeader::new(payload, timestamp,
                 include_in_index, random_access, discontinuity);
+            gst_memdump!(CAT, obj: element, "render: writing event={:?}", event);
             let mut event_writer = EventWriter::new();
             event_writer.write(&event, writer).map_err(|err| {
                 gst::element_error!(

--- a/gst-plugin-pravega/src/pravegasink/imp.rs
+++ b/gst-plugin-pravega/src/pravegasink/imp.rs
@@ -62,6 +62,13 @@ pub enum TimestampMode {
         nick = "ntp"
     )]
     Ntp = 1,
+    #[genum(
+        name = "Input buffer timestamps are nanoseconds \
+                since 1970-01-01 00:00:00 TAI International Atomic Time, including leap seconds. \
+                Use this for pravegasrc (start-pts-at-zero=false).",
+        nick = "tai"
+    )]
+    Tai = 2,
 }
 
 const DEFAULT_CONTROLLER: &str = "127.0.0.1:9090";
@@ -609,6 +616,9 @@ impl BaseSinkImpl for PravegaSink {
                 // Note: base_time is the value of the pipeline clock at the beginning of play. It is ignored.
                 PravegaTimestamp::from_ntp_nanoseconds(pts.nseconds())
             },
+            TimestampMode::Tai => {
+                PravegaTimestamp::from_nanoseconds(pts.nseconds())
+            }
         };
 
         gst_log!(CAT, obj: element, "render: timestamp={}, pts={}, base_time={}, duration={}, size={}",

--- a/gst-plugin-pravega/src/pravegasrc/imp.rs
+++ b/gst-plugin-pravega/src/pravegasrc/imp.rs
@@ -786,7 +786,9 @@ impl BaseSrcImpl for PravegaSrc {
                     }
                 }
             } else {
-                gst_info!(CAT, obj: src, "do_seek: not performing initial seek because start-mode=no-seek; segment={:?}", segment);
+                let head_offset = reader.get_ref().get_ref().get_ref().current_head().unwrap();
+                reader.seek(SeekFrom::Start(head_offset)).unwrap();
+                gst_info!(CAT, obj: src, "do_seek: Seeking to head of data stream because start-mode=no-seek; segment={:?}", segment);
                 true
             }
         })();

--- a/gst-plugin-pravega/src/pravegasrc/imp.rs
+++ b/gst-plugin-pravega/src/pravegasrc/imp.rs
@@ -655,7 +655,7 @@ impl BaseSrcImpl for PravegaSrc {
                 PravegaTimestamp::from_nanoseconds(Some(settings.start_timestamp))
             },
         };
-        gst_info!(CAT, obj: element, "start: start_timestamp={}", start_timestamp);
+        gst_info!(CAT, obj: element, "start: start_timestamp={:?}", start_timestamp);
 
         // end_offset is the byte offset in the data stream.
         // The data stream reader will be configured to never read beyond this offset.
@@ -828,7 +828,7 @@ impl BaseSrcImpl for PravegaSrc {
     }
 
     fn stop(&self, element: &Self::Type) -> Result<(), gst::ErrorMessage> {
-        gst_info!(CAT, obj: element, "Stopping");
+        gst_info!(CAT, obj: element, "stop: Stopping");
         let mut state = self.state.lock().unwrap();
         if let State::Stopped = *state {
             return Err(gst::error_msg!(
@@ -837,7 +837,7 @@ impl BaseSrcImpl for PravegaSrc {
             ));
         }
         *state = State::Stopped;
-        gst_info!(CAT, obj: element, "Stopped");
+        gst_info!(CAT, obj: element, "stop: Stopped");
         Ok(())
     }
 }
@@ -898,7 +898,7 @@ impl PushSrcImpl for PravegaSrc {
             // If start_pts_at_zero=false (default), segment.get_time() equals 0 so the PTS will equal
             // the timestamp stored in the Pravega timestamp.
             let pts = ClockTime(event.header.timestamp.nanoseconds()) - segment.get_time();
-            gst_log!(CAT, obj: element, "create: timestamp={}, pts={}, payload_len={}",
+            gst_log!(CAT, obj: element, "create: timestamp={:?}, pts={}, payload_len={}",
                 event.header.timestamp, pts, event.payload.len());
 
             buffer_ref.set_pts(pts);

--- a/gst-plugin-pravega/src/pravegasrc/imp.rs
+++ b/gst-plugin-pravega/src/pravegasrc/imp.rs
@@ -888,6 +888,7 @@ impl PushSrcImpl for PravegaSrc {
             let reader = &mut (*reader);
 
             let mut event_reader = EventReader::new();
+            // TODO: This likely flushes the BufReader.
             let offset = reader.stream_position().unwrap();
             let required_buffer_length = event_reader.read_required_buffer_length(reader).map_err(|err| {
                 if err.kind() == ErrorKind::UnexpectedEof {

--- a/gst-plugin-pravega/src/pravegasrc/imp.rs
+++ b/gst-plugin-pravega/src/pravegasrc/imp.rs
@@ -8,7 +8,9 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 //
 
-// A source that reads GStreamer buffers along with timestamps, as written by pravegasink.
+// A source that reads GStreamer buffers from a Pravega stream, as written by pravegasink.
+// Based on:
+//   - https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/tree/master/generic/file/src/filesrc
 
 use glib::subclass::prelude::*;
 use gst::ClockTime;

--- a/gst-plugin-pravega/src/pravegasrc/imp.rs
+++ b/gst-plugin-pravega/src/pravegasrc/imp.rs
@@ -693,12 +693,12 @@ impl BaseSrcImpl for PravegaSrc {
             drop(settings);
             gst_info!(CAT, obj: element, "start: Started");
 
-            if let Some(seek_pos) = start_timestamp.nanoseconds() {
-                element.seek_simple(
-                    gst::SeekFlags::FLUSH | gst::SeekFlags::KEY_UNIT,
-                    seek_pos * gst::NSECOND,
-                ).unwrap();
-            }
+            // if let Some(seek_pos) = start_timestamp.nanoseconds() {
+            //     element.seek_simple(
+            //         gst::SeekFlags::FLUSH | gst::SeekFlags::KEY_UNIT,
+            //         seek_pos * gst::NSECOND,
+            //     ).unwrap();
+            // }
 
             Ok(())
         })();

--- a/gst-plugin-pravega/src/pravegasrc/imp.rs
+++ b/gst-plugin-pravega/src/pravegasrc/imp.rs
@@ -581,7 +581,9 @@ impl BaseSrcImpl for PravegaSrc {
         // Create scope.
         gst_info!(CAT, obj: element, "allow_create_scope={}", settings.allow_create_scope);
         if settings.allow_create_scope {
-            runtime.block_on(controller_client.create_scope(&scope)).unwrap();
+            runtime.block_on(controller_client.create_scope(&scope)).map_err(|error| {
+                gst::error_msg!(gst::ResourceError::Settings, ["Failed to create Pravega scope: {:?}", error])
+            })?;
         }
 
         // Create data stream.
@@ -597,7 +599,9 @@ impl BaseSrcImpl for PravegaSrc {
             },
             retention: Default::default(),
         };
-        runtime.block_on(controller_client.create_stream(&stream_config)).unwrap();
+        runtime.block_on(controller_client.create_stream(&stream_config)).map_err(|error| {
+            gst::error_msg!(gst::ResourceError::Settings, ["Failed to create Pravega data stream: {:?}", error])
+        })?;
 
         // Create index stream.
         let index_stream_config = StreamConfiguration {
@@ -612,7 +616,9 @@ impl BaseSrcImpl for PravegaSrc {
             },
             retention: Default::default(),
         };
-        runtime.block_on(controller_client.create_stream(&index_stream_config)).unwrap();
+        runtime.block_on(controller_client.create_stream(&index_stream_config)).map_err(|error| {
+            gst::error_msg!(gst::ResourceError::Settings, ["Failed to create Pravega index stream: {:?}", error])
+        })?;
 
         let scoped_segment = ScopedSegment {
             scope: scope.clone(),

--- a/gst-plugin-pravega/src/pravegasrc/imp.rs
+++ b/gst-plugin-pravega/src/pravegasrc/imp.rs
@@ -680,8 +680,9 @@ impl BaseSrcImpl for PravegaSrc {
             reader: Arc::new(Mutex::new(buf_reader)),
             index_searcher: Arc::new(Mutex::new(index_searcher)),
         };
-        // We must unlock the state so that seek does not deadlock.
+        // We must drop locks so that seek does not deadlock.
         drop(state);
+        drop(settings);
         gst_info!(CAT, obj: element, "Started");
 
         if let Some(seek_pos) = start_timestamp.nanoseconds() {

--- a/gst-plugin-pravega/src/seekable_byte_stream_writer.rs
+++ b/gst-plugin-pravega/src/seekable_byte_stream_writer.rs
@@ -1,0 +1,50 @@
+//
+// Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+
+use pravega_client::byte_stream::ByteStreamWriter;
+use std::io::{Error, ErrorKind, Result, Seek, SeekFrom, Write};
+
+/// A ByteStreamWriter that implements Seek.
+pub struct SeekableByteStreamWriter {
+    inner: ByteStreamWriter,
+}
+
+impl SeekableByteStreamWriter {
+    pub fn new(writer: ByteStreamWriter) -> Result<SeekableByteStreamWriter> {
+        let writer = SeekableByteStreamWriter {
+            inner: writer
+        };
+        Ok(writer)
+    }
+
+    /// Gets a mutable reference to the underlying writer.
+    pub fn get_mut(&mut self) -> &mut ByteStreamWriter {
+        &mut self.inner
+    }
+}
+
+impl Write for SeekableByteStreamWriter {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.inner.flush()
+    }
+}
+
+impl Seek  for SeekableByteStreamWriter {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        match pos {
+            SeekFrom::Current(0) => Ok(self.inner.current_write_offset() as u64),
+            _ => Err(Error::new(ErrorKind::InvalidInput, "Seek is not allowed")),
+        }
+    }
+}

--- a/gst-plugin-pravega/src/seekable_byte_stream_writer.rs
+++ b/gst-plugin-pravega/src/seekable_byte_stream_writer.rs
@@ -24,6 +24,11 @@ impl SeekableByteStreamWriter {
         Ok(writer)
     }
 
+    /// Gets a reference to the underlying reader.
+    pub fn get_ref(&self) -> &ByteStreamWriter {
+        &self.inner
+    }
+
     /// Gets a mutable reference to the underlying writer.
     pub fn get_mut(&mut self) -> &mut ByteStreamWriter {
         &mut self.inner

--- a/gst-plugin-pravega/src/utils.rs
+++ b/gst-plugin-pravega/src/utils.rs
@@ -1,0 +1,20 @@
+//
+// Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+
+use gst::ClockTime;
+use pravega_video::timestamp::PravegaTimestamp;
+
+pub fn clocktime_to_pravega(t: ClockTime) -> PravegaTimestamp {
+    PravegaTimestamp::from_nanoseconds(t.nanoseconds())
+}
+
+pub fn pravega_to_clocktime(t: PravegaTimestamp) -> ClockTime {
+    ClockTime(t.nanoseconds())
+}


### PR DESCRIPTION
General enhancements:
- Improve logging
- Replace unwrap with returned errors
- No longer allow timestamp 0 in index

pravegasrc:
- Fix deadlock and incorrect seeking behavior
- Add CountingReader to prevent buffer flush when getting current position
- Add offset, offset_end properties to buffers for debugging

pravegasink:
- Add timestamp-mode=tai
- Add SeekableByteStreamWriter and CountingWriter