### PR TITLE
pravega-video-server: Disable list_video_streams due to breaking API change

### DIFF
--- a/pravega-video-server/src/main.rs
+++ b/pravega-video-server/src/main.rs
@@ -470,13 +470,15 @@ mod models {
             scope_name: String,
         ) -> anyhow::Result<ListStreamsResult> {
             tracing::info!("list_video_streams: scope_name={}", scope_name);
-            let controller_client = self.client_factory.get_controller_client();
-            let stream_names = controller_client.list_streams(&Scope::from(scope_name.clone())).await.unwrap();
-            let streams: Vec<_> = stream_names.into_iter().map(|stream_name| ListStreamsRecord {
-                scope_name: scope_name.clone(),
-                stream_name,
-            }).collect();
-            Ok(ListStreamsResult { streams })
+            // TODO: Need to use new list_streams API or completely remove the feature.
+            anyhow::bail!("unsupported");
+            // let controller_client = self.client_factory.get_controller_client();
+            // let stream_names = controller_client.list_streams(&Scope::from(scope_name.clone())).await.unwrap();
+            // let streams: Vec<_> = stream_names.into_iter().map(|stream_name| ListStreamsRecord {
+            //     scope_name: scope_name.clone(),
+            //     stream_name,
+            // }).collect();
+            // Ok(ListStreamsResult { streams })
         }
     }
 }

--- a/scripts/test-unit.sh
+++ b/scripts/test-unit.sh
@@ -25,7 +25,6 @@ pushd ${ROOT_DIR}/pravega-video
 cargo test $*
 popd
 
-# TODO: Below fails to compile.
-# pushd ${ROOT_DIR}/pravega-video-server
-# cargo test $*
-# popd
+pushd ${ROOT_DIR}/pravega-video-server
+cargo test $*
+popd


### PR DESCRIPTION
The Pravega API for list_streams had a recent breaking change which causes a build failure. Since we do not need list_streams functionality in pravega-video-server, this PR disables it temporarily. An HTTP request to pravega-video-server to list streams will return an error to the HTTP client.