### PR TITLE
pravegasink: set discontinuity flag on first buffer

### DIFF
--- a/gst-plugin-pravega/src/counting_reader.rs
+++ b/gst-plugin-pravega/src/counting_reader.rs
@@ -8,6 +8,8 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 //
 
+#![allow(dead_code)]
+
 use std::io::{Read, Result, Seek, SeekFrom};
 
 /// Read adaptor that tracks the current offset so it can be returned without seeking the inner reader.

--- a/gst-plugin-pravega/src/counting_writer.rs
+++ b/gst-plugin-pravega/src/counting_writer.rs
@@ -8,6 +8,8 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 //
 
+#![allow(dead_code)]
+
 use std::io::{Write, Result, Seek, SeekFrom};
 
 /// Write adaptor that tracks the current offset so it can be returned without seeking the inner writer.

--- a/gst-plugin-pravega/src/seekable_byte_stream_writer.rs
+++ b/gst-plugin-pravega/src/seekable_byte_stream_writer.rs
@@ -8,6 +8,8 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 //
 
+#![allow(dead_code)]
+
 use pravega_client::byte_stream::ByteStreamWriter;
 use std::io::{Error, ErrorKind, Result, Seek, SeekFrom, Write};
 

--- a/gst-plugin-pravega/src/seekable_take.rs
+++ b/gst-plugin-pravega/src/seekable_take.rs
@@ -8,6 +8,8 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 //
 
+#![allow(dead_code)]
+
 use std::io::{Read, Result, Seek, SeekFrom, Take};
 
 /// Reader adaptor which returns EOF beyond the specified end position.


### PR DESCRIPTION
This fixes timestamps produced by tsdemux when reading a stream produced by two invocations of pravegasink.
This PR also fixes some compiler warnings.