### PR TITLE
pravegasrc: Set segment start time to allow playback with sync=true

### DIFF
--- a/gst-plugin-pravega/src/pravegasink/imp.rs
+++ b/gst-plugin-pravega/src/pravegasink/imp.rs
@@ -67,7 +67,7 @@ pub enum TimestampMode {
     #[genum(
         name = "Input buffer timestamps are nanoseconds \
                 since 1970-01-01 00:00:00 TAI International Atomic Time, including leap seconds. \
-                Use this for buffers from pravegasrc (start-pts-at-zero=false).",
+                Use this for buffers from pravegasrc.",
         nick = "tai"
     )]
     Tai = 2,

--- a/scripts/mp4-test5.sh
+++ b/scripts/mp4-test5.sh
@@ -56,7 +56,6 @@ pravegasrc \
   allow-create-scope=${ALLOW_CREATE_SCOPE} \
   controller=${PRAVEGA_CONTROLLER_URI} \
   keycloak-file=\"${KEYCLOAK_SERVICE_ACCOUNT_FILE}\" \
-  start-pts-at-zero=true \
   stream=${PRAVEGA_SCOPE}/${PRAVEGA_STREAM} \
 ! identity silent=false name=pravegasrc \
 ! decodebin \

--- a/scripts/pravega-to-screen-docker.sh
+++ b/scripts/pravega-to-screen-docker.sh
@@ -29,7 +29,6 @@ pravegasrc \
   stream=${PRAVEGA_SCOPE}/${PRAVEGA_STREAM} \
   controller=${PRAVEGA_CONTROLLER_URI} \
   allow-create-scope=${ALLOW_CREATE_SCOPE} \
-  start-pts-at-zero=true \
   $* \
 ! decodebin \
 ! videoconvert \

--- a/scripts/pravega-to-screen.sh
+++ b/scripts/pravega-to-screen.sh
@@ -31,7 +31,6 @@ pravegasrc \
   allow-create-scope=${ALLOW_CREATE_SCOPE} \
   controller=${PRAVEGA_CONTROLLER_URI} \
   keycloak-file=\"${KEYCLOAK_SERVICE_ACCOUNT_FILE}\" \
-  start-pts-at-zero=true \
   stream=${PRAVEGA_SCOPE}/${PRAVEGA_STREAM} \
   $* \
 ! decodebin \

--- a/scripts/pravega-to-speaker-split.sh
+++ b/scripts/pravega-to-speaker-split.sh
@@ -27,7 +27,7 @@ PRAVEGA_STREAM=${PRAVEGA_STREAM:-split1}
 
 gst-launch-1.0 \
 -v \
-pravegasrc stream=examples/${PRAVEGA_STREAM}-a1 start-pts-at-zero=true \
+pravegasrc stream=examples/${PRAVEGA_STREAM}-a1 \
 ! tsdemux \
 ! avdec_aac \
 ! audioconvert \

--- a/scripts/pravega-video-player.sh
+++ b/scripts/pravega-video-player.sh
@@ -12,6 +12,10 @@
 
 set -ex
 ROOT_DIR=$(readlink -f $(dirname $0)/..)
+pushd ${ROOT_DIR}/gst-plugin-pravega
+cargo build
+popd
+export GST_PLUGIN_PATH=${ROOT_DIR}/gst-plugin-pravega/target/debug:${GST_PLUGIN_PATH}
 # log level can be INFO or LOG (verbose)
 export GST_DEBUG="pravegasrc:INFO,basesrc:INFO,mpegtsbase:INFO,mpegtspacketizer:INFO"
 export RUST_LOG=info
@@ -21,6 +25,6 @@ PRAVEGA_CONTROLLER_URI=${PRAVEGA_CONTROLLER_URI:-127.0.0.1:9090}
 export GST_DEBUG_DUMP_DOT_DIR=/tmp/gst-dot/pravega-video-player
 mkdir -p ${GST_DEBUG_DUMP_DOT_DIR}
 pushd ${ROOT_DIR}/apps
-cargo run --release --bin pravega-video-player -- --stream examples/${PRAVEGA_STREAM} --controller ${PRAVEGA_CONTROLLER_URI} $* \
-|& tee /mnt/data/logs/pravega-video-player.log
+cargo run --bin pravega-video-player -- --stream examples/${PRAVEGA_STREAM} --controller ${PRAVEGA_CONTROLLER_URI} $* \
+|& tee /tmp/pravega-video-player.log
 popd


### PR DESCRIPTION
- Set segment start time to allow playback with sync=true.
- Change default start-mode to earliest.
- Remove obsolete start-pts-at-zero property.

Signed-off-by: Claudio Fahey <claudio.fahey@dell.com>