### PR TITLE
docker: Remove GL dependency to avoid error with missing xdg-shell-client-protocol.h

### DIFF
--- a/docker/docker/build-gstreamer/compile
+++ b/docker/docker/build-gstreamer/compile
@@ -17,12 +17,12 @@ for repo in gstreamer libnice gst-plugins-base gst-plugins-bad gst-plugins-good 
   # TODO: Hack: `-D gupnp=disabled` is for libnice, because libgupnp-igd causes memory leaks
   if [[ $DEBUG == 'true' ]]; then
     if [[ $OPTIMIZATIONS == 'true' ]]; then
-      meson build -D prefix=/usr -D gupnp=disabled -D msdk=enabled -D debug=true -D optimization=2
+      meson build -D prefix=/usr -D gupnp=disabled -D msdk=enabled -D with_x11=no -D gl=disabled -D debug=true -D optimization=2
     else
-      meson build -D prefix=/usr -D gupnp=disabled -D msdk=enabled -D debug=true
+      meson build -D prefix=/usr -D gupnp=disabled -D msdk=enabled -D with_x11=no -D gl=disabled -D debug=true
     fi
   else
-    meson build -D prefix=/usr -D gupnp=disabled -D msdk=enabled -D debug=false -D optimization=3 -D b_lto=true -D buildtype=release
+    meson build -D prefix=/usr -D gupnp=disabled -D msdk=enabled -D with_x11=no -D gl=disabled -D debug=false -D optimization=3 -D b_lto=true -D buildtype=release
   fi
   # This is needed for other plugins to be built properly
   ninja -C build install

--- a/docker/docker/build-gstreamer/install-dependencies
+++ b/docker/docker/build-gstreamer/install-dependencies
@@ -108,6 +108,7 @@ apt-get install -y --no-install-recommends \
   libtag1-dev \
   libtheora-dev \
   libtwolame-dev \
+  libudev-dev \
   libunwind-dev \
   libva-dev \
   libvisual-0.4-dev \


### PR DESCRIPTION
Applied fixes from https://github.com/restreamio/docker-gstreamer/commit/ea80e076230a6f5ea1332573438564b5abbf037a.

Signed-off-by: Claudio Fahey <claudio.fahey@dell.com>