### PR TITLE
Download in parallel

### DIFF
--- a/docker/docker/build-gstreamer/download
+++ b/docker/docker/build-gstreamer/download
@@ -12,42 +12,28 @@
 
 set -ex
 
-git clone --no-checkout "$GSTREAMER_REPOSITORY"
-pushd gstreamer
-git checkout "$GSTREAMER_CHECKOUT"
-popd
+checkoutInRepo() {
+    pushd $1
+    git checkout $2
+    popd
+}
 
-git clone --no-checkout "$LIBNICE_REPOSITORY"
-pushd libnice
-git checkout "$LIBNICE_CHECKOUT"
-popd
+git clone --no-checkout "$GSTREAMER_REPOSITORY" &
+git clone --no-checkout "$LIBNICE_REPOSITORY" &
+git clone --no-checkout "$GST_PLUGINS_BASE_REPOSITORY" &
+git clone --no-checkout "$GST_PLUGINS_BAD_REPOSITORY" &
+git clone --no-checkout "$GST_PLUGINS_GOOD_REPOSITORY" &
+git clone --no-checkout "$GST_PLUGINS_UGLY_REPOSITORY" &
+git clone --no-checkout "$GST_LIBAV_REPOSITORY" &
+git clone --no-checkout "$GST_RTSP_SERVER_REPOSITORY" &
 
-git clone --no-checkout "$GST_PLUGINS_BASE_REPOSITORY"
-pushd gst-plugins-base
-git checkout "$GST_PLUGINS_BASE_CHECKOUT"
-popd
+wait
 
-git clone --no-checkout "$GST_PLUGINS_BAD_REPOSITORY"
-pushd gst-plugins-bad
-git checkout "$GST_PLUGINS_BAD_CHECKOUT"
-popd
-
-git clone --no-checkout "$GST_PLUGINS_GOOD_REPOSITORY"
-pushd gst-plugins-good
-git checkout "$GST_PLUGINS_GOOD_CHECKOUT"
-popd
-
-git clone --no-checkout "$GST_PLUGINS_UGLY_REPOSITORY"
-pushd gst-plugins-ugly
-git checkout "$GST_PLUGINS_UGLY_CHECKOUT"
-popd
-
-git clone --no-checkout "$GST_LIBAV_REPOSITORY"
-pushd gst-libav
-git checkout "$GST_LIBAV_CHECKOUT"
-popd
-
-git clone --no-checkout "$GST_RTSP_SERVER_REPOSITORY"
-pushd gst-rtsp-server
-git checkout "$GST_RTSP_SERVER_CHECKOUT"
-popd
+checkoutInRepo gstreamer "$GSTREAMER_CHECKOUT"
+checkoutInRepo libnice "$LIBNICE_CHECKOUT"
+checkoutInRepo gst-plugins-base "$GST_PLUGINS_BASE_CHECKOUT"
+checkoutInRepo gst-plugins-bad "$GST_PLUGINS_BAD_CHECKOUT"
+checkoutInRepo gst-plugins-good "$GST_PLUGINS_GOOD_CHECKOUT"
+checkoutInRepo gst-plugins-ugly "$GST_PLUGINS_UGLY_CHECKOUT"
+checkoutInRepo gst-libav "$GST_LIBAV_CHECKOUT"
+checkoutInRepo gst-rtsp-server "$GST_RTSP_SERVER_CHECKOUT"


### PR DESCRIPTION
Download the Gstreamer repositories in parallel; checkout sequentially.

On my computer and internet connection, doing them sequentially takes 91s. Doing them in parallel is 31s (most is I/O waiting).

"Free" easy speed boost.