### PR TITLE
Optimize Dockerfile

### DIFF
--- a/docker/build-release.sh
+++ b/docker/build-release.sh
@@ -17,48 +17,54 @@ GSTREAMER_CHECKOUT=${GSTREAMER_CHECKOUT:-1.18.4}
 RUST_JOBS=${RUST_JOBS:-4}
 DOCKER_REPOSITORY=${DOCKER_REPOSITORY}
 
-# Make sure to always have fresh base image
-#docker pull ${DOCKER_REPOSITORY}ubuntu:20.10
+# Make sure to always have fresh base image.
+if [[ "${PULL_BASE}" != "0" ]]; then
+    docker pull ${DOCKER_REPOSITORY}ubuntu:20.10
+fi
 
 # Build pravega-prod image which includes the binaries for all applications.
-docker build -t pravega/gstreamer:pravega-prod \
-    --build-arg GSTREAMER_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gstreamer.git \
-    --build-arg GSTREAMER_CHECKOUT=${GSTREAMER_CHECKOUT} \
-    --build-arg GST_PLUGINS_BASE_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-base.git \
-    --build-arg GST_PLUGINS_BASE_CHECKOUT=${GSTREAMER_CHECKOUT} \
-    --build-arg GST_PLUGINS_BAD_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad.git \
-    --build-arg GST_PLUGINS_BAD_CHECKOUT=${GSTREAMER_CHECKOUT} \
-    --build-arg GST_PLUGINS_GOOD_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-good.git \
-    --build-arg GST_PLUGINS_GOOD_CHECKOUT=${GSTREAMER_CHECKOUT} \
-    --build-arg GST_PLUGINS_UGLY_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-ugly.git \
-    --build-arg GST_PLUGINS_UGLY_CHECKOUT=${GSTREAMER_CHECKOUT} \
-    --build-arg GST_LIBAV_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-libav.git \
-    --build-arg GST_LIBAV_CHECKOUT=${GSTREAMER_CHECKOUT} \
-    --build-arg GST_RTSP_SERVER_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-rtsp-server.git \
-    --build-arg GST_RTSP_SERVER_CHECKOUT=${GSTREAMER_CHECKOUT} \
-    --build-arg RUST_JOBS=${RUST_JOBS} \
-    --build-arg DOCKER_REPOSITORY=${DOCKER_REPOSITORY} \
-    --target prod \
-    -f ${ROOT_DIR}/docker/pravega-dev.Dockerfile ${ROOT_DIR}
+if [[ "${BUILD_PROD}" != "0" ]]; then
+    docker build -t pravega/gstreamer:pravega-prod \
+        --build-arg GSTREAMER_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gstreamer.git \
+        --build-arg GSTREAMER_CHECKOUT=${GSTREAMER_CHECKOUT} \
+        --build-arg GST_PLUGINS_BASE_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-base.git \
+        --build-arg GST_PLUGINS_BASE_CHECKOUT=${GSTREAMER_CHECKOUT} \
+        --build-arg GST_PLUGINS_BAD_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad.git \
+        --build-arg GST_PLUGINS_BAD_CHECKOUT=${GSTREAMER_CHECKOUT} \
+        --build-arg GST_PLUGINS_GOOD_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-good.git \
+        --build-arg GST_PLUGINS_GOOD_CHECKOUT=${GSTREAMER_CHECKOUT} \
+        --build-arg GST_PLUGINS_UGLY_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-ugly.git \
+        --build-arg GST_PLUGINS_UGLY_CHECKOUT=${GSTREAMER_CHECKOUT} \
+        --build-arg GST_LIBAV_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-libav.git \
+        --build-arg GST_LIBAV_CHECKOUT=${GSTREAMER_CHECKOUT} \
+        --build-arg GST_RTSP_SERVER_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-rtsp-server.git \
+        --build-arg GST_RTSP_SERVER_CHECKOUT=${GSTREAMER_CHECKOUT} \
+        --build-arg RUST_JOBS=${RUST_JOBS} \
+        --build-arg DOCKER_REPOSITORY=${DOCKER_REPOSITORY} \
+        --target prod \
+        -f ${ROOT_DIR}/docker/pravega.Dockerfile ${ROOT_DIR}
+fi
 
 # Build pravega-dev image which includes the source code and binaries for all applications.
 # This is a cache hit 100%.
-docker build -t pravega/gstreamer:pravega-dev \
-    --build-arg GSTREAMER_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gstreamer.git \
-    --build-arg GSTREAMER_CHECKOUT=${GSTREAMER_CHECKOUT} \
-    --build-arg GST_PLUGINS_BASE_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-base.git \
-    --build-arg GST_PLUGINS_BASE_CHECKOUT=${GSTREAMER_CHECKOUT} \
-    --build-arg GST_PLUGINS_BAD_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad.git \
-    --build-arg GST_PLUGINS_BAD_CHECKOUT=${GSTREAMER_CHECKOUT} \
-    --build-arg GST_PLUGINS_GOOD_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-good.git \
-    --build-arg GST_PLUGINS_GOOD_CHECKOUT=${GSTREAMER_CHECKOUT} \
-    --build-arg GST_PLUGINS_UGLY_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-ugly.git \
-    --build-arg GST_PLUGINS_UGLY_CHECKOUT=${GSTREAMER_CHECKOUT} \
-    --build-arg GST_LIBAV_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-libav.git \
-    --build-arg GST_LIBAV_CHECKOUT=${GSTREAMER_CHECKOUT} \
-    --build-arg GST_RTSP_SERVER_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-rtsp-server.git \
-    --build-arg GST_RTSP_SERVER_CHECKOUT=${GSTREAMER_CHECKOUT} \
-    --build-arg RUST_JOBS=${RUST_JOBS} \
-    --build-arg DOCKER_REPOSITORY=${DOCKER_REPOSITORY} \
-    --target pravega-dev \
-    -f ${ROOT_DIR}/docker/pravega-dev.Dockerfile ${ROOT_DIR}
+if [[ "${BUILD_DEV}" != "0" ]]; then
+    docker build -t pravega/gstreamer:pravega-dev \
+        --build-arg GSTREAMER_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gstreamer.git \
+        --build-arg GSTREAMER_CHECKOUT=${GSTREAMER_CHECKOUT} \
+        --build-arg GST_PLUGINS_BASE_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-base.git \
+        --build-arg GST_PLUGINS_BASE_CHECKOUT=${GSTREAMER_CHECKOUT} \
+        --build-arg GST_PLUGINS_BAD_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad.git \
+        --build-arg GST_PLUGINS_BAD_CHECKOUT=${GSTREAMER_CHECKOUT} \
+        --build-arg GST_PLUGINS_GOOD_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-good.git \
+        --build-arg GST_PLUGINS_GOOD_CHECKOUT=${GSTREAMER_CHECKOUT} \
+        --build-arg GST_PLUGINS_UGLY_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-ugly.git \
+        --build-arg GST_PLUGINS_UGLY_CHECKOUT=${GSTREAMER_CHECKOUT} \
+        --build-arg GST_LIBAV_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-libav.git \
+        --build-arg GST_LIBAV_CHECKOUT=${GSTREAMER_CHECKOUT} \
+        --build-arg GST_RTSP_SERVER_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-rtsp-server.git \
+        --build-arg GST_RTSP_SERVER_CHECKOUT=${GSTREAMER_CHECKOUT} \
+        --build-arg RUST_JOBS=${RUST_JOBS} \
+        --build-arg DOCKER_REPOSITORY=${DOCKER_REPOSITORY} \
+        --target pravega-dev \
+        -f ${ROOT_DIR}/docker/pravega.Dockerfile ${ROOT_DIR}
+fi

--- a/docker/build-release.sh
+++ b/docker/build-release.sh
@@ -24,7 +24,8 @@ fi
 
 # Build pravega-prod image which includes the binaries for all applications.
 if [[ "${BUILD_PROD}" != "0" ]]; then
-    docker build -t pravega/gstreamer:pravega-prod \
+    docker build \
+        -t pravega/gstreamer:pravega-prod \
         --build-arg GSTREAMER_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gstreamer.git \
         --build-arg GSTREAMER_CHECKOUT=${GSTREAMER_CHECKOUT} \
         --build-arg GST_PLUGINS_BASE_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-base.git \
@@ -42,13 +43,15 @@ if [[ "${BUILD_PROD}" != "0" ]]; then
         --build-arg RUST_JOBS=${RUST_JOBS} \
         --build-arg DOCKER_REPOSITORY=${DOCKER_REPOSITORY} \
         --target prod \
-        -f ${ROOT_DIR}/docker/pravega.Dockerfile ${ROOT_DIR}
+        -f ${ROOT_DIR}/docker/pravega.Dockerfile \
+        ${ROOT_DIR}
 fi
 
 # Build pravega-dev image which includes the source code and binaries for all applications.
 # This is a cache hit 100%.
 if [[ "${BUILD_DEV}" != "0" ]]; then
-    docker build -t pravega/gstreamer:pravega-dev \
+    docker build \
+        -t pravega/gstreamer:pravega-dev \
         --build-arg GSTREAMER_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gstreamer.git \
         --build-arg GSTREAMER_CHECKOUT=${GSTREAMER_CHECKOUT} \
         --build-arg GST_PLUGINS_BASE_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-base.git \
@@ -66,5 +69,6 @@ if [[ "${BUILD_DEV}" != "0" ]]; then
         --build-arg RUST_JOBS=${RUST_JOBS} \
         --build-arg DOCKER_REPOSITORY=${DOCKER_REPOSITORY} \
         --target pravega-dev \
-        -f ${ROOT_DIR}/docker/pravega.Dockerfile ${ROOT_DIR}
+        -f ${ROOT_DIR}/docker/pravega.Dockerfile \
+        ${ROOT_DIR}
 fi

--- a/docker/pravega.Dockerfile
+++ b/docker/pravega.Dockerfile
@@ -95,7 +95,14 @@ RUN cargo install cargo-chef --jobs ${RUST_JOBS}
 
 # Create Cargo Chef recipe.
 FROM chef-base as planner
-COPY . .
+COPY Cargo.toml .
+COPY Cargo.lock .
+COPY apps apps
+COPY deepstream/pravega_protocol_adapter deepstream/pravega_protocol_adapter
+COPY gst-plugin-pravega gst-plugin-pravega
+COPY integration-test integration-test
+COPY pravega-video pravega-video
+COPY pravega-video-server pravega-video-server
 RUN cargo chef prepare --recipe-path recipe.json
 
 

--- a/docker/pravega.Dockerfile
+++ b/docker/pravega.Dockerfile
@@ -114,7 +114,6 @@ RUN cargo chef cook --release --recipe-path recipe.json
 
 # Build GStreamer Pravega libraries and applications.
 FROM builder-base as pravega-dev
-ARG RUST_JOBS=1
 
 ARG RUST_JOBS=1
 


### PR DESCRIPTION
This PR includes various improvements to the the main Dockerfile.

1. Rename pravega-dev.Dockerfile to pravega.Dockerfile since this is no longer just for development.
2. Building of dev and prod images can be disabled with env vars.
3. Always pull the base Ubuntu image unless PULL_BASE=0.
4. Rename stage "base" to "debug-prod-compile".
5. Cargo chef prepare now copies specific directories instead of all files.