### PR TITLE
cargo test with locked & release

### DIFF
--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -30,9 +30,9 @@ export RUST_BACKTRACE=0
 
 # Build tests then print list of test names.
 # This will ignore any tests with names containing "ignore".
-cargo test $* -- --skip ignore --list \
+cargo test --release --locked $* -- --skip ignore --list \
 |& tee /tmp/integration-test.log
 
 # Run tests.
-cargo test $* -- --skip ignore --nocapture --test-threads=${TEST_THREADS} \
+cargo test --release --locked $* -- --skip ignore --nocapture --test-threads=${TEST_THREADS} \
 |& tee -a /tmp/integration-test.log

--- a/scripts/test-unit.sh
+++ b/scripts/test-unit.sh
@@ -20,9 +20,9 @@ for comp in apps gst-plugin-pravega pravega-video pravega-video-server; do
     path_to_cargo2junit=$(which cargo2junit)
     set -e
     if [ -x "$path_to_cargo2junit" ] ; then
-        cargo test $* -- -Z unstable-options --format json | cargo2junit | tee junit.xml
+        cargo test --locked --release $* -- -Z unstable-options --format json | cargo2junit | tee junit.xml
     else
-        cargo test
+        cargo test --locked --release
     fi
 
     popd


### PR DESCRIPTION
Not having `--locked --release` in the test means that when building in a container that only builds w/ `--locked --release` means that everything will be recompiled.

I thought about putting it behind a flag but I don't see much utility. If one did have a failing test and wanted the debug build, they could individually run the test on the commandline.