### PR TITLE
Toggle to export integration test results to junit format

### DIFF
--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -27,12 +27,19 @@ TEST_THREADS=${TEST_THREADS:-1}
 
 pushd ${ROOT_DIR}/integration-test
 export RUST_BACKTRACE=0
+export JUNIT_OUTPUT=${JUNIT_OUTPUT:-0}
 
 # Build tests then print list of test names.
 # This will ignore any tests with names containing "ignore".
 cargo test --release --locked $* -- --skip ignore --list \
 |& tee /tmp/integration-test.log
 
-# Run tests.
-cargo test --release --locked $* -- --skip ignore --nocapture --test-threads=${TEST_THREADS} \
-|& tee -a /tmp/integration-test.log
+if [[ "${BUILD_PROD}" != "0" ]]; then
+    # Run tests.
+    cargo test --release --locked $* -- --skip ignore --nocapture --test-threads=${TEST_THREADS} \
+    -Z unstable-options --format json | cargo2junit | tee junit.xml
+else
+    # Run tests.
+    cargo test --release --locked $* -- --skip ignore --nocapture --test-threads=${TEST_THREADS} \
+    |& tee -a /tmp/integration-test.log
+fi


### PR DESCRIPTION
Environment variable (JUNIT_OUTPUT) that is zero to output in the normal format or non-zero to output the results in junit format.