### PR TITLE
Check prereqs before integration tests

### DIFF
--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -13,6 +13,28 @@
 set -ex
 ROOT_DIR=$(readlink -f $(dirname $0)/..)
 
+commandExists() {
+    if ! command -v "$1" &> /dev/null
+    then
+        echo "$1 could not be found"
+        exit
+    fi
+}
+commandExists netstat
+commandExists ss
+commandExists grep
+commandExists java
+version=$(java --version 2>&1) #Some versions of java --version output to stderr
+
+case "$version" in
+    *"openjdk 11"*)
+        ;;
+    *"java 11"*)
+        ;;
+    *)
+       >&2 echo "Need Java JDK 11"
+esac
+
 # If PRAVEGA_CONTROLLER_URI is not set, then Pravega standalone will be started and stopped by the integration test.
 # For example: export PRAVEGA_CONTROLLER_URI=127.0.0.1:9090
 


### PR DESCRIPTION
This is to save us from odd errors later on where Pravega won't launch (missing Java 11) or we can't inspect if Pravega is running (missing netstat, ss, or grep).

I wrote this in the rust code originally but it was ugly. I feel doing it early in the short shell code tidier.