### PR TITLE
pravega-video-server: Accept parameters through env vars

### DIFF
--- a/docker/pravega.Dockerfile
+++ b/docker/pravega.Dockerfile
@@ -162,7 +162,7 @@ COPY --from=debug-prod-compile /compiled-binaries /
 COPY --from=pravega-dev /usr/src/gstreamer-pravega/python_apps /usr/src/gstreamer-pravega/python_apps
 ENV PATH=/usr/src/gstreamer-pravega/python_apps:$PATH
 COPY --from=pravega-dev /usr/lib/x86_64-linux-gnu/gstreamer-1.0/ /usr/lib/x86_64-linux-gnu/gstreamer-1.0/
-COPY --from=pravega-dev /usr/src/gstreamer-pravega/target/release/pravega-video-server .
+COPY --from=pravega-dev /usr/src/gstreamer-pravega/target/release/pravega-video-server /usr/local/bin/
 
 
 # Build GStreamer without debug symbols.
@@ -178,4 +178,4 @@ COPY --from=prod-compile /compiled-binaries /
 COPY --from=pravega-dev /usr/src/gstreamer-pravega/python_apps /usr/src/gstreamer-pravega/python_apps
 ENV PATH=/usr/src/gstreamer-pravega/python_apps:$PATH
 COPY --from=pravega-dev /usr/lib/x86_64-linux-gnu/gstreamer-1.0/ /usr/lib/x86_64-linux-gnu/gstreamer-1.0/
-COPY --from=pravega-dev /usr/src/gstreamer-pravega/target/release/pravega-video-server .
+COPY --from=pravega-dev /usr/src/gstreamer-pravega/target/release/pravega-video-server /usr/local/bin/

--- a/pravega-video-server/src/main.rs
+++ b/pravega-video-server/src/main.rs
@@ -20,12 +20,12 @@ use warp::Filter;
 /// Point your browser to: http://localhost:3030/player?scope=examples&stream=hlsav4
 #[derive(Clap)]
 struct Opts {
-    /// Pravega controller in format "127.0.0.1:9090"
-    #[clap(short, long, default_value = "127.0.0.1:9090")]
-    controller: String,
+    /// Pravega controller in format "tcp://127.0.0.1:9090"
+    #[clap(long, env = "PRAVEGA_CONTROLLER_URI", default_value = "tcp://127.0.0.1:9090")]
+    pravega_controller_uri: String,
     /// The filename containing the Keycloak credentials JSON. If missing or empty, authentication will be disabled.
-    #[clap(short, long, default_value = "", setting(clap::ArgSettings::AllowEmptyValues))]
-    keycloak_file: String,
+    #[clap(long, env = "KEYCLOAK_SERVICE_ACCOUNT_FILE", default_value = "", setting(clap::ArgSettings::AllowEmptyValues))]
+    keycloak_service_account_file: String,
 }
 
 fn main() {
@@ -41,7 +41,7 @@ fn main() {
 
     // Let Pravega ClientFactory create the Tokio runtime. It will also be used by Warp.
 
-    let config = create_client_config(opts.controller, Some(opts.keycloak_file)).expect("creating config");
+    let config = create_client_config(opts.pravega_controller_uri, Some(opts.keycloak_service_account_file)).expect("creating config");
     let client_factory = ClientFactory::new(config);
     let client_factory_db = client_factory.clone();
     let runtime = client_factory.runtime();

--- a/scripts/pravega-video-server.sh
+++ b/scripts/pravega-video-server.sh
@@ -15,7 +15,6 @@ ROOT_DIR=$(readlink -f $(dirname $0)/..)
 # log level can be INFO or LOG (verbose)
 export RUST_LOG=info
 export RUST_BACKTRACE=1
-PRAVEGA_CONTROLLER_URI=${PRAVEGA_CONTROLLER_URI:-127.0.0.1:9090}
 pushd ${ROOT_DIR}/pravega-video-server
 cargo run -- $* \
 |& tee /tmp/pravega-video-server.log

--- a/scripts/pravega-video-server.sh
+++ b/scripts/pravega-video-server.sh
@@ -17,9 +17,6 @@ export RUST_LOG=info
 export RUST_BACKTRACE=1
 PRAVEGA_CONTROLLER_URI=${PRAVEGA_CONTROLLER_URI:-127.0.0.1:9090}
 pushd ${ROOT_DIR}/pravega-video-server
-cargo run -- \
---controller ${PRAVEGA_CONTROLLER_URI} \
---keycloak-file "${KEYCLOAK_SERVICE_ACCOUNT_FILE}" \
-$* \
+cargo run -- $* \
 |& tee /tmp/pravega-video-server.log
 popd


### PR DESCRIPTION
- Rename parameters for pravega-video-server and accept parameters through env vars.
- Change Dockerfile to place pravega-video-server binary in /usr/local/bin so that it is in the path.