### PR TITLE
Remove cors workaround

### DIFF
--- a/pravega-video-server/src/main.rs
+++ b/pravega-video-server/src/main.rs
@@ -60,13 +60,10 @@ fn main() {
         // let redirect = warp::path::end().map(|| {
         //     warp::redirect::temporary(Uri::from_static("/static/hls-js.html"))
         // });
-        // TODO: For testing, configure CORS to allow access from any origin. This needs to be removed or limited for production.
-        let cors = warp::cors().allow_any_origin();
+
         let routes = api
             .or(ui)
             .or(static_dir)
-            // .or(redirect)
-            .with(cors)
             .with(warp::trace::request());
         warp::serve(routes).run(([0, 0, 0, 0], 3030)).await;
     })


### PR DESCRIPTION
In another channel Claudio and I talked about this.

From a security prospective, it is better to have one or more of the following:

- The user view the player directly (and perhaps we enhance the webplayer with more features)
- Let other apps that want video to go through the API on their backend
- Iframe the video player

CORs has some limitation such as browsers not allowing CORs for localhost. 