### PR TITLE
disable python log buffer so that log flushes immediately after logging

### DIFF
--- a/k8s/charts/rtsp-camera-to-pravega/values.yaml
+++ b/k8s/charts/rtsp-camera-to-pravega/values.yaml
@@ -11,6 +11,7 @@ appParameters:
   CAMERA_PROTOCOLS: "tcp"
   GST_DEBUG: "WARNING,rtspsrc:INFO,rtpbin:INFO,rtpsession:INFO,rtpjitterbuffer:INFO,h264parse:WARN,pravegasink:DEBUG"
   pravega_client_tls_cert_path: "/etc/ssl/certs/ca-certificates.crt"
+  PYTHONUNBUFFERED: "1"
 healthCheck:
   enabled: false
   idleSeconds: 30

--- a/k8s/charts/rtsp-camera-to-pravega/values.yaml
+++ b/k8s/charts/rtsp-camera-to-pravega/values.yaml
@@ -11,7 +11,6 @@ appParameters:
   CAMERA_PROTOCOLS: "tcp"
   GST_DEBUG: "WARNING,rtspsrc:INFO,rtpbin:INFO,rtpsession:INFO,rtpjitterbuffer:INFO,h264parse:WARN,pravegasink:DEBUG"
   pravega_client_tls_cert_path: "/etc/ssl/certs/ca-certificates.crt"
-  PYTHONUNBUFFERED: "1"
 healthCheck:
   enabled: false
   idleSeconds: 30

--- a/python_apps/rtsp-camera-to-pravega.py
+++ b/python_apps/rtsp-camera-to-pravega.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S python3 -u
 
 #
 # Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.


### PR DESCRIPTION
To minimize code invasion, just add the env param to disable log buffer.

To test:
```
helm install rtsp-camera-to-pravega-1 ./gstreamer-pravega/k8s/charts/rtsp-camera-to-pravega -n luis --set image.repository=devops-repo.isus.emc.com:8116/nautilus/gstreamer:luis,global.camera.address=10.243.54.95,global.camera.user=admin,global.camera.password=password,global.camera.rtspPort=8554,global.pravega.stream=pipeline512m,healthCheck.enabled=true,healthCheck.idleSeconds=30,appParameters.CAMERA_PATH="/cam/realmonitor?width=640&height=480",appParameters.GST_DEBUG="WARNING",appParameters.PRAVEGA_RETENTION_POLICY_TYPE=bytes,appParameters.PRAVEGA_RETENTION_BYTES=536870912
```