### PR TITLE
add tools and libs for the deepstream dev pod

### DIFF
--- a/deepstream/deepstream-dev-pod.Dockerfile
+++ b/deepstream/deepstream-dev-pod.Dockerfile
@@ -24,7 +24,11 @@ RUN apt-get update && \
         nano \
         openssh-server \
         sudo \
-        wget
+        wget \
+        netcat \
+        curl \
+        iputils-ping \
+        dnsutils
 
 RUN mkdir /var/run/sshd
 RUN useradd -rm -d /home/ubuntu -s /bin/bash -g root -G sudo -u 1001 ubuntu
@@ -36,7 +40,12 @@ RUN apt-get install -y --no-install-recommends \
         python3-dev \
         python3-gi \
         python3-gst-1.0 \
-        python3-pip
+        python3-pip \
+        python3-opencv \
+        python3-numpy \
+        libgstrtspserver-1.0-0 gstreamer1.0-rtsp \
+        libgirepository1.0-dev \
+        gobject-introspection gir1.2-gst-rtsp-server-1.0
 RUN cd /opt/nvidia/deepstream/deepstream/lib && \
     python3 setup.py install && \
     cd /opt/nvidia/deepstream/deepstream/sources && \

--- a/deepstream/deepstream-dev-pod.Dockerfile
+++ b/deepstream/deepstream-dev-pod.Dockerfile
@@ -20,15 +20,15 @@ RUN update-ca-certificates
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        curl \
+        dnsutils \
+        iputils-ping \
         less \
         nano \
+        netcat \
         openssh-server \
         sudo \
-        wget \
-        netcat \
-        curl \
-        iputils-ping \
-        dnsutils
+        wget
 
 RUN mkdir /var/run/sshd
 RUN useradd -rm -d /home/ubuntu -s /bin/bash -g root -G sudo -u 1001 ubuntu
@@ -36,16 +36,19 @@ RUN echo "ubuntu ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 # Install Python Bindings for DeepStream.
 RUN apt-get install -y --no-install-recommends \
+        gir1.2-gst-rtsp-server-1.0 \
+        gobject-introspection \
+        gstreamer1.0-rtsp \
+        libgirepository1.0-dev \
+        libgstrtspserver-1.0-0 \
         python3-configargparse \
         python3-dev \
         python3-gi \
         python3-gst-1.0 \
-        python3-pip \
-        python3-opencv \
         python3-numpy \
-        libgstrtspserver-1.0-0 gstreamer1.0-rtsp \
-        libgirepository1.0-dev \
-        gobject-introspection gir1.2-gst-rtsp-server-1.0
+        python3-opencv \
+        python3-pip
+        
 RUN cd /opt/nvidia/deepstream/deepstream/lib && \
     python3 setup.py install && \
     cd /opt/nvidia/deepstream/deepstream/sources && \


### PR DESCRIPTION
1. Add tools of netcat (nc), curl, ping, and dig
2. Add libs of python3-opencv, python3-numpy, libgstrtspserver-1.0-0, gstreamer1.0-rtsp, libgirepository1.0-dev, gobject-introspection, gir1.2-gst-rtsp-server-1.0 that is needed by the python examples