### PR TITLE
Optional local volume for pravega up

### DIFF
--- a/pravega-docker/docker-compose.yml
+++ b/pravega-docker/docker-compose.yml
@@ -103,8 +103,10 @@ services:
         ipv4_address: 172.28.1.41
     restart: always
     volumes:
-      - ${PRAVEGA_LTS_PATH:-/tmp/pravega-lts}:/pravega-lts
+      - ${PRAVEGA_LTS_PATH:-pravega-lts-volume}:/pravega-lts
 
+volumes:
+  pravega-lts-volume:
 networks:
   pravega_net:
     ipam:

--- a/pravega-docker/up.sh
+++ b/pravega-docker/up.sh
@@ -14,9 +14,14 @@ set -ex
 ROOT_DIR=$(readlink -f $(dirname $0))
 cd ${ROOT_DIR}
 export HOST_IP=${HOST_IP:-192.168.120.128}
-export PRAVEGA_LTS_PATH=${PRAVEGA_LTS_PATH:-/tmp/pravega-lts}
-docker-compose down
-sudo rm -rf ${PRAVEGA_LTS_PATH}
+export PRAVEGA_LTS_PATH=${PRAVEGA_LTS_PATH-/tmp/pravega-lts}
+docker-compose down -v
+
+if ! [ -z "${PRAVEGA_LTS_PATH}" ]
+then
+    sudo rm -rf ${PRAVEGA_LTS_PATH}
+fi
+
 docker-compose up -d
 sleep 20s
 curl -X POST -H "Content-Type: application/json" -d '{"scopeName":"examples"}' http://localhost:10080/v1/scopes


### PR DESCRIPTION
Option to not use a local volume in pravega-docker/up.sh. Saves a "sudo" password typing.

On a scale of 1-10, where 7 is "I think this really should go in", this is a 3. 