### PR TITLE
upgrade to the lastst pravega rust client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2773,7 +2773,7 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 [[package]]
 name = "pravega-client"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=8954c04f4c5530374128f905bf49dda5d7bcef0e#8954c04f4c5530374128f905bf49dda5d7bcef0e"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=6614df550bd286e3d1867022c3f235836c6cc278#6614df550bd286e3d1867022c3f235836c6cc278"
 dependencies = [
  "ahash 0.6.3",
  "async-stream 0.2.1",
@@ -2812,7 +2812,7 @@ dependencies = [
 [[package]]
 name = "pravega-client-auth"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=8954c04f4c5530374128f905bf49dda5d7bcef0e#8954c04f4c5530374128f905bf49dda5d7bcef0e"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=6614df550bd286e3d1867022c3f235836c6cc278#6614df550bd286e3d1867022c3f235836c6cc278"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -2827,7 +2827,7 @@ dependencies = [
 [[package]]
 name = "pravega-client-channel"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=8954c04f4c5530374128f905bf49dda5d7bcef0e#8954c04f4c5530374128f905bf49dda5d7bcef0e"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=6614df550bd286e3d1867022c3f235836c6cc278#6614df550bd286e3d1867022c3f235836c6cc278"
 dependencies = [
  "futures-intrusive 0.4.0",
  "tokio 1.5.0",
@@ -2836,7 +2836,7 @@ dependencies = [
 [[package]]
 name = "pravega-client-config"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=8954c04f4c5530374128f905bf49dda5d7bcef0e#8954c04f4c5530374128f905bf49dda5d7bcef0e"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=6614df550bd286e3d1867022c3f235836c6cc278#6614df550bd286e3d1867022c3f235836c6cc278"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -2855,7 +2855,7 @@ dependencies = [
 [[package]]
 name = "pravega-client-retry"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=8954c04f4c5530374128f905bf49dda5d7bcef0e#8954c04f4c5530374128f905bf49dda5d7bcef0e"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=6614df550bd286e3d1867022c3f235836c6cc278#6614df550bd286e3d1867022c3f235836c6cc278"
 dependencies = [
  "snafu",
  "tokio 1.5.0",
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "pravega-client-shared"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=8954c04f4c5530374128f905bf49dda5d7bcef0e#8954c04f4c5530374128f905bf49dda5d7bcef0e"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=6614df550bd286e3d1867022c3f235836c6cc278#6614df550bd286e3d1867022c3f235836c6cc278"
 dependencies = [
  "async-trait",
  "bytes 0.4.12",
@@ -2882,13 +2882,14 @@ dependencies = [
  "shrinkwraprs",
  "snafu",
  "tokio 1.5.0",
+ "tokio-rustls",
  "uuid",
 ]
 
 [[package]]
 name = "pravega-connection-pool"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=8954c04f4c5530374128f905bf49dda5d7bcef0e#8954c04f4c5530374128f905bf49dda5d7bcef0e"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=6614df550bd286e3d1867022c3f235836c6cc278#6614df550bd286e3d1867022c3f235836c6cc278"
 dependencies = [
  "async-trait",
  "dashmap 3.11.10",
@@ -2902,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "pravega-controller-client"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=8954c04f4c5530374128f905bf49dda5d7bcef0e#8954c04f4c5530374128f905bf49dda5d7bcef0e"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=6614df550bd286e3d1867022c3f235836c6cc278#6614df550bd286e3d1867022c3f235836c6cc278"
 dependencies = [
  "async-trait",
  "clap 2.33.3",
@@ -2976,7 +2977,7 @@ dependencies = [
 [[package]]
 name = "pravega-wire-protocol"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=8954c04f4c5530374128f905bf49dda5d7bcef0e#8954c04f4c5530374128f905bf49dda5d7bcef0e"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=6614df550bd286e3d1867022c3f235836c6cc278#6614df550bd286e3d1867022c3f235836c6cc278"
 dependencies = [
  "async-trait",
  "bincode2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,7 +1358,6 @@ version = "0.7.0"
 dependencies = [
  "chrono",
  "enumflags2",
- "futures",
  "glib",
  "gst-plugin-version-helper",
  "gstreamer",
@@ -2940,7 +2939,6 @@ dependencies = [
  "chrono",
  "enumflags2",
  "env_logger",
- "futures",
  "once_cell",
  "pravega-client",
  "pravega-client-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,6 +1358,7 @@ version = "0.7.0"
 dependencies = [
  "chrono",
  "enumflags2",
+ "futures",
  "glib",
  "gst-plugin-version-helper",
  "gstreamer",
@@ -1902,6 +1903,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls",
+ "tokio 1.5.0",
+ "tokio-rustls",
+ "webpki",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2362,6 +2378,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint 0.4.0",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2370,6 +2400,37 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2383,12 +2444,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
  "autocfg",
+ "num-bigint 0.4.0",
  "num-integer",
  "num-traits",
 ]
@@ -2701,7 +2774,7 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 [[package]]
 name = "pravega-client"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=9ed43aaefabfb2750a2361419a7232200e6ed4a0#9ed43aaefabfb2750a2361419a7232200e6ed4a0"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=8954c04f4c5530374128f905bf49dda5d7bcef0e#8954c04f4c5530374128f905bf49dda5d7bcef0e"
 dependencies = [
  "ahash 0.6.3",
  "async-stream 0.2.1",
@@ -2740,7 +2813,7 @@ dependencies = [
 [[package]]
 name = "pravega-client-auth"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=9ed43aaefabfb2750a2361419a7232200e6ed4a0#9ed43aaefabfb2750a2361419a7232200e6ed4a0"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=8954c04f4c5530374128f905bf49dda5d7bcef0e#8954c04f4c5530374128f905bf49dda5d7bcef0e"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -2755,7 +2828,7 @@ dependencies = [
 [[package]]
 name = "pravega-client-channel"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=9ed43aaefabfb2750a2361419a7232200e6ed4a0#9ed43aaefabfb2750a2361419a7232200e6ed4a0"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=8954c04f4c5530374128f905bf49dda5d7bcef0e#8954c04f4c5530374128f905bf49dda5d7bcef0e"
 dependencies = [
  "futures-intrusive 0.4.0",
  "tokio 1.5.0",
@@ -2764,7 +2837,7 @@ dependencies = [
 [[package]]
 name = "pravega-client-config"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=9ed43aaefabfb2750a2361419a7232200e6ed4a0#9ed43aaefabfb2750a2361419a7232200e6ed4a0"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=8954c04f4c5530374128f905bf49dda5d7bcef0e#8954c04f4c5530374128f905bf49dda5d7bcef0e"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -2783,7 +2856,7 @@ dependencies = [
 [[package]]
 name = "pravega-client-retry"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=9ed43aaefabfb2750a2361419a7232200e6ed4a0#9ed43aaefabfb2750a2361419a7232200e6ed4a0"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=8954c04f4c5530374128f905bf49dda5d7bcef0e#8954c04f4c5530374128f905bf49dda5d7bcef0e"
 dependencies = [
  "snafu",
  "tokio 1.5.0",
@@ -2792,7 +2865,7 @@ dependencies = [
 [[package]]
 name = "pravega-client-shared"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=9ed43aaefabfb2750a2361419a7232200e6ed4a0#9ed43aaefabfb2750a2361419a7232200e6ed4a0"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=8954c04f4c5530374128f905bf49dda5d7bcef0e#8954c04f4c5530374128f905bf49dda5d7bcef0e"
 dependencies = [
  "async-trait",
  "bytes 0.4.12",
@@ -2800,8 +2873,12 @@ dependencies = [
  "derive_more",
  "encoding_rs",
  "im",
+ "lazy_static",
  "murmurhash3",
+ "num-derive",
+ "num-traits",
  "ordered-float 1.1.1",
+ "regex",
  "serde",
  "shrinkwraprs",
  "snafu",
@@ -2812,7 +2889,7 @@ dependencies = [
 [[package]]
 name = "pravega-connection-pool"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=9ed43aaefabfb2750a2361419a7232200e6ed4a0#9ed43aaefabfb2750a2361419a7232200e6ed4a0"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=8954c04f4c5530374128f905bf49dda5d7bcef0e#8954c04f4c5530374128f905bf49dda5d7bcef0e"
 dependencies = [
  "async-trait",
  "dashmap 3.11.10",
@@ -2826,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "pravega-controller-client"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=9ed43aaefabfb2750a2361419a7232200e6ed4a0#9ed43aaefabfb2750a2361419a7232200e6ed4a0"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=8954c04f4c5530374128f905bf49dda5d7bcef0e#8954c04f4c5530374128f905bf49dda5d7bcef0e"
 dependencies = [
  "async-trait",
  "clap 2.33.3",
@@ -2834,6 +2911,9 @@ dependencies = [
  "futures",
  "im",
  "jsonwebtoken",
+ "num",
+ "num-derive",
+ "num-traits",
  "ordered-float 1.1.1",
  "pravega-client-config",
  "pravega-client-retry",
@@ -2845,6 +2925,7 @@ dependencies = [
  "snafu",
  "structopt",
  "tokio 1.5.0",
+ "tokio-rustls",
  "tonic",
  "tonic-build",
  "tracing",
@@ -2859,6 +2940,7 @@ dependencies = [
  "chrono",
  "enumflags2",
  "env_logger",
+ "futures",
  "once_cell",
  "pravega-client",
  "pravega-client-config",
@@ -2896,7 +2978,7 @@ dependencies = [
 [[package]]
 name = "pravega-wire-protocol"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=9ed43aaefabfb2750a2361419a7232200e6ed4a0#9ed43aaefabfb2750a2361419a7232200e6ed4a0"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=8954c04f4c5530374128f905bf49dda5d7bcef0e#8954c04f4c5530374128f905bf49dda5d7bcef0e"
 dependencies = [
  "async-trait",
  "bincode2",
@@ -3245,6 +3327,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -3254,15 +3337,18 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite 0.2.6",
+ "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio 1.5.0",
  "tokio-native-tls",
+ "tokio-rustls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -3550,7 +3636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
 dependencies = [
  "chrono",
- "num-bigint",
+ "num-bigint 0.2.6",
  "num-traits",
 ]
 
@@ -4404,6 +4490,15 @@ checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -33,9 +33,9 @@ gst-rtsp-server = { package = "gstreamer-rtsp-server", git = "https://gitlab.fre
 gst-sdp = { package = "gstreamer-sdp", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs" }
 gstreamer-video = { git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs" }
 gtk = { git = "https://github.com/gtk-rs/gtk-rs" }
-pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
-pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
-pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
+pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
+pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
 pravega-video = { path = "../pravega-video" }
 log = "0.4"
 serde = "1"

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -33,9 +33,9 @@ gst-rtsp-server = { package = "gstreamer-rtsp-server", git = "https://gitlab.fre
 gst-sdp = { package = "gstreamer-sdp", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs" }
 gstreamer-video = { git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs" }
 gtk = { git = "https://github.com/gtk-rs/gtk-rs" }
-pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
-pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
-pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
+pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
 pravega-video = { path = "../pravega-video" }
 log = "0.4"
 serde = "1"

--- a/apps/src/bin/pravega_event_test1.rs
+++ b/apps/src/bin/pravega_event_test1.rs
@@ -76,6 +76,7 @@ fn main() {
                 ..Default::default()
             },
             retention: Default::default(),
+            tags: None,
         };
         controller_client.create_stream(&stream_config).await.unwrap();
         let num_events: u64 = 3;

--- a/apps/src/bin/pravega_event_test2.rs
+++ b/apps/src/bin/pravega_event_test2.rs
@@ -66,6 +66,7 @@ fn main() {
                 ..Default::default()
             },
             retention: Default::default(),
+            tags: None,
         };
         controller_client.create_stream(&stream_config).await.unwrap();
 

--- a/deepstream/pravega_protocol_adapter/Cargo.toml
+++ b/deepstream/pravega_protocol_adapter/Cargo.toml
@@ -18,9 +18,9 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
-pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
-pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
+pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
+pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
 pravega-video = { path = "../../pravega-video" }
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/deepstream/pravega_protocol_adapter/Cargo.toml
+++ b/deepstream/pravega_protocol_adapter/Cargo.toml
@@ -18,9 +18,9 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
-pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
-pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
+pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
 pravega-video = { path = "../../pravega-video" }
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/deepstream/pravega_protocol_adapter/src/lib.rs
+++ b/deepstream/pravega_protocol_adapter/src/lib.rs
@@ -112,6 +112,7 @@ impl EventWriterPool {
                         ..Default::default()
                     },
                     retention: Default::default(),
+                    tags: None,
                 };
                 let create_stream_result = controller_client.create_stream(&stream_config).await.unwrap();
                 info!("EventWriterPool::get_or_create: Stream created, create_stream_result={}", create_stream_result);

--- a/gst-plugin-pravega/Cargo.toml
+++ b/gst-plugin-pravega/Cargo.toml
@@ -19,7 +19,6 @@ edition = "2018"
 [dependencies]
 chrono = "0.4"
 enumflags2 = { version = "0.6", features = ["serde"]}
-futures = "0.3"
 glib = { git = "https://github.com/gtk-rs/gtk-rs" }
 gst = { package = "gstreamer", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs" }
 gst-base = { package = "gstreamer-base", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs" }

--- a/gst-plugin-pravega/Cargo.toml
+++ b/gst-plugin-pravega/Cargo.toml
@@ -23,9 +23,9 @@ glib = { git = "https://github.com/gtk-rs/gtk-rs" }
 gst = { package = "gstreamer", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs" }
 gst-base = { package = "gstreamer-base", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs" }
 once_cell = "1"
-pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
-pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
-pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
+pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
+pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
 pravega-video = { path = "../pravega-video" }
 
 [lib]

--- a/gst-plugin-pravega/Cargo.toml
+++ b/gst-plugin-pravega/Cargo.toml
@@ -19,13 +19,14 @@ edition = "2018"
 [dependencies]
 chrono = "0.4"
 enumflags2 = { version = "0.6", features = ["serde"]}
+futures = "0.3"
 glib = { git = "https://github.com/gtk-rs/gtk-rs" }
 gst = { package = "gstreamer", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs" }
 gst-base = { package = "gstreamer-base", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs" }
 once_cell = "1"
-pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
-pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
-pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
+pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
 pravega-video = { path = "../pravega-video" }
 
 [lib]

--- a/gst-plugin-pravega/src/pravegasink/imp.rs
+++ b/gst-plugin-pravega/src/pravegasink/imp.rs
@@ -767,6 +767,7 @@ impl BaseSinkImpl for PravegaSink {
                     ..Default::default()
                 },
                 retention: Default::default(),
+                tags: None,
             };
             runtime.block_on(controller_client.create_stream(&stream_config)).map_err(|error| {
                 gst::error_msg!(gst::ResourceError::Settings, ["Failed to create Pravega data stream: {:?}", error])
@@ -784,6 +785,7 @@ impl BaseSinkImpl for PravegaSink {
                     ..Default::default()
                 },
                 retention: Default::default(),
+                tags: None,
             };
             runtime.block_on(controller_client.create_stream(&index_stream_config)).map_err(|error| {
                 gst::error_msg!(gst::ResourceError::Settings, ["Failed to create Pravega index stream: {:?}", error])

--- a/gst-plugin-pravega/src/pravegasrc/imp.rs
+++ b/gst-plugin-pravega/src/pravegasrc/imp.rs
@@ -779,7 +779,7 @@ impl BaseSrcImpl for PravegaSrc {
                 segment.set_start(0);
                 segment.set_time(0);
                 segment.set_position(0);
-                let head_offset = executor::block_on(reader.get_ref().get_ref().get_ref().current_head()).unwrap();
+                let head_offset = reader.get_ref().get_ref().get_ref().current_head().unwrap();
                 reader.seek(SeekFrom::Start(head_offset)).unwrap();
                 gst_info!(CAT, obj: src, "do_seek: Starting at head of data stream because start-mode=no-seek; segment={:?}", segment);
                 true

--- a/gst-plugin-pravega/src/pravegasrc/imp.rs
+++ b/gst-plugin-pravega/src/pravegasrc/imp.rs
@@ -26,7 +26,6 @@ use std::sync::{Arc, Mutex};
 use std::u8;
 
 use once_cell::sync::Lazy;
-use futures::executor;
 
 use pravega_client::client_factory::ClientFactory;
 use pravega_client::byte::ByteReader;

--- a/integration-test/Cargo.toml
+++ b/integration-test/Cargo.toml
@@ -32,9 +32,9 @@ gst-rtsp-server = { package = "gstreamer-rtsp-server", git = "https://gitlab.fre
 java-properties = "1.2"
 lazy_static = "1.4"
 once_cell = "1.7.2"
-pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
-pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
-pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
+pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
 pravega-video = { path = "../pravega-video" }
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
 tracing-subscriber = "0.2"

--- a/integration-test/Cargo.toml
+++ b/integration-test/Cargo.toml
@@ -32,9 +32,9 @@ gst-rtsp-server = { package = "gstreamer-rtsp-server", git = "https://gitlab.fre
 java-properties = "1.2"
 lazy_static = "1.4"
 once_cell = "1.7.2"
-pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
-pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
-pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
+pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
+pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
 pravega-video = { path = "../pravega-video" }
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
 tracing-subscriber = "0.2"

--- a/pravega-video-server/Cargo.toml
+++ b/pravega-video-server/Cargo.toml
@@ -24,10 +24,10 @@ futures = "0.3"
 futures-util = "0.3"
 handlebars = "3"
 hyper = "0.14"
-pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
-pravega-controller-client = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-controller-client", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
-pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
-pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
+pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-controller-client = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-controller-client", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
 pravega-video = { path = "../pravega-video" }
 serde = "1"
 serde_derive = "1"

--- a/pravega-video-server/Cargo.toml
+++ b/pravega-video-server/Cargo.toml
@@ -24,10 +24,10 @@ futures = "0.3"
 futures-util = "0.3"
 handlebars = "3"
 hyper = "0.14"
-pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
-pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
-pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
-pravega-controller-client = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-controller-client", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
+pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
+pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
+pravega-controller-client = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-controller-client", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
 pravega-video = { path = "../pravega-video" }
 serde = "1"
 serde_derive = "1"

--- a/pravega-video/Cargo.toml
+++ b/pravega-video/Cargo.toml
@@ -22,9 +22,9 @@ chrono = "0.4"
 enumflags2 = { version = "0.6", features = ["serde"]}
 env_logger = "0.7"
 once_cell = "1"
-pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
-pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
-pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
+pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
+pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "6614df550bd286e3d1867022c3f235836c6cc278" }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 

--- a/pravega-video/Cargo.toml
+++ b/pravega-video/Cargo.toml
@@ -21,7 +21,6 @@ anyhow = "1"
 chrono = "0.4"
 enumflags2 = { version = "0.6", features = ["serde"]}
 env_logger = "0.7"
-futures = "0.3"
 once_cell = "1"
 pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
 pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }

--- a/pravega-video/Cargo.toml
+++ b/pravega-video/Cargo.toml
@@ -21,10 +21,11 @@ anyhow = "1"
 chrono = "0.4"
 enumflags2 = { version = "0.6", features = ["serde"]}
 env_logger = "0.7"
+futures = "0.3"
 once_cell = "1"
-pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
-pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
-pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "9ed43aaefabfb2750a2361419a7232200e6ed4a0" }
+pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
+pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "8954c04f4c5530374128f905bf49dda5d7bcef0e" }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 

--- a/pravega-video/src/utils.rs
+++ b/pravega-video/src/utils.rs
@@ -12,7 +12,6 @@
 
 use std::net::{SocketAddr, AddrParseError};
 use std::time::{Duration, UNIX_EPOCH};
-use std::io::{Seek, SeekFrom};
 
 use pravega_client::byte::ByteReader;
 use pravega_client_config::{ClientConfig, ClientConfigBuilder};
@@ -52,7 +51,7 @@ pub fn create_client_config(controller: String, keycloak_file: Option<String>) -
             if keycloak_file.is_empty() {
                 (false, Credentials::basic("".into(), "".into()))
             } else {
-                (true, Credentials::keycloak(&keycloak_file[..]))
+                (true, Credentials::keycloak(&keycloak_file[..], false))
             }
         },
         None => (false, Credentials::basic("".into(), "".into()))

--- a/pravega-video/src/utils.rs
+++ b/pravega-video/src/utils.rs
@@ -20,13 +20,13 @@ use pravega_client_config::credentials::Credentials;
 /// A trait that allows retrieval of the current head of a Pravega byte stream.
 /// The default implementation returns 0 to indicate that no data has been truncated.
 pub trait CurrentHead {
-    fn current_head(&mut self) -> std::io::Result<u64> {
+    fn current_head(&self) -> std::io::Result<u64> {
         Ok(0)
     }
 }
 
 impl CurrentHead for ByteReader {
-    fn current_head(&mut self) -> std::io::Result<u64> {
+    fn current_head(&self) -> std::io::Result<u64> {
         self.current_head()
     }
 }

--- a/pravega-video/src/utils.rs
+++ b/pravega-video/src/utils.rs
@@ -12,7 +12,7 @@
 
 use std::net::{SocketAddr, AddrParseError};
 use std::time::{Duration, UNIX_EPOCH};
-use futures::executor;
+use std::io::{Seek, SeekFrom};
 
 use pravega_client::byte::ByteReader;
 use pravega_client_config::{ClientConfig, ClientConfigBuilder};
@@ -21,14 +21,14 @@ use pravega_client_config::credentials::Credentials;
 /// A trait that allows retrieval of the current head of a Pravega byte stream.
 /// The default implementation returns 0 to indicate that no data has been truncated.
 pub trait CurrentHead {
-    fn current_head(&self) -> std::io::Result<u64> {
+    fn current_head(&mut self) -> std::io::Result<u64> {
         Ok(0)
     }
 }
 
 impl CurrentHead for ByteReader {
-    fn current_head(&self) -> std::io::Result<u64> {
-        executor::block_on(self.current_head())
+    fn current_head(&mut self) -> std::io::Result<u64> {
+        self.current_head()
     }
 }
 


### PR DESCRIPTION
1. Upgrade gstreamer-pravega to latest Pravega Rust client 6614df550bd286e3d1867022c3f235836c6cc278
2. Update GStreamer plugins to pass Keycloak credentials via API 

Verified by running camera recorder pipeline and playing with pravega video server and check retention policy work. 
The lastest image build: devops-repo.isus.emc.com:8116/nautilus/gstreamer:luis
