### PR TITLE
Use Video Tags

### DIFF
--- a/apps/src/bin/pravega_event_test1.rs
+++ b/apps/src/bin/pravega_event_test1.rs
@@ -19,6 +19,8 @@ use pravega_client::client_factory::ClientFactory;
 use pravega_client_config::ClientConfigBuilder;
 use pravega_client_shared::{Scope, Stream, StreamConfiguration, ScopedStream, Scaling, ScaleType};
 
+use pravega_video::utils;
+
 #[derive(Clap)]
 struct Opts {
     /// Pravega controller in format "127.0.0.1:9090"
@@ -71,7 +73,7 @@ fn main() {
                 ..Default::default()
             },
             retention: Default::default(),
-            tags: None,
+            tags: utils::get_video_tags(),
         };
         controller_client.create_stream(&stream_config).await.unwrap();
         let num_events: u64 = 3;

--- a/apps/src/bin/pravega_event_test2.rs
+++ b/apps/src/bin/pravega_event_test2.rs
@@ -18,6 +18,8 @@ use pravega_client::client_factory::ClientFactory;
 use pravega_client_config::ClientConfigBuilder;
 use pravega_client_shared::{Scope, Stream, StreamConfiguration, ScopedStream, Scaling, ScaleType};
 
+use pravega_video::utils;
+
 #[derive(Clap)]
 struct Opts {
     /// Pravega controller in format "127.0.0.1:9090"
@@ -66,7 +68,7 @@ fn main() {
                 ..Default::default()
             },
             retention: Default::default(),
-            tags: None,
+            tags: utils::get_video_tags(),
         };
         controller_client.create_stream(&stream_config).await.unwrap();
 

--- a/gst-plugin-pravega/src/pravegasink/imp.rs
+++ b/gst-plugin-pravega/src/pravegasink/imp.rs
@@ -150,7 +150,7 @@ impl RetentionMaintainer {
             interval_seconds,
             retention_policy,
             factory,
-            index_searcher, 
+            index_searcher,
             index_writer,
             data_writer,
         }
@@ -172,7 +172,7 @@ impl RetentionMaintainer {
         if seconds.is_none() && bytes.is_none() {
             return None;
         }
-        
+
         gst_info!(CAT, obj: &self.element, "start: retention_maintainer_interval_seconds={}", self.interval_seconds);
         let handle = thread::spawn(move || {
             loop {
@@ -767,7 +767,7 @@ impl BaseSinkImpl for PravegaSink {
                     ..Default::default()
                 },
                 retention: Default::default(),
-                tags: None,
+                tags: utils::get_video_tags(),
             };
             runtime.block_on(controller_client.create_stream(&stream_config)).map_err(|error| {
                 gst::error_msg!(gst::ResourceError::Settings, ["Failed to create Pravega data stream: {:?}", error])
@@ -811,12 +811,12 @@ impl BaseSinkImpl for PravegaSink {
             gst_info!(CAT, obj: element, "start: Buffer size is {}", settings.buffer_size);
             let buf_writer = BufWriter::with_capacity(settings.buffer_size, seekable_writer);
             let counting_writer = CountingWriter::new(buf_writer).unwrap();
-            
+
             let retention_policy = RetentionPolicy::new(settings.retention_type, settings.retention_days, settings.retention_bytes).map_err(|error| {
                 gst::error_msg!(gst::ResourceError::Settings, ["Failed to create retention policy: {}", error])
             })?;
             gst_info!(CAT, obj: element, "start: retention_policy={:?}", retention_policy);
-            
+
             let retention_maintainer = RetentionMaintainer::new(element.clone(), settings.retention_maintenance_interval_seconds, retention_policy, client_factory.clone(),
                 index_scoped_stream, scoped_stream);
             let (retention_thread_stop_tx, retention_thread_stop_rx) = mpsc::channel();

--- a/gst-plugin-pravega/src/pravegasrc/imp.rs
+++ b/gst-plugin-pravega/src/pravegasrc/imp.rs
@@ -584,7 +584,7 @@ impl BaseSrcImpl for PravegaSrc {
                     ..Default::default()
                 },
                 retention: Default::default(),
-                tags: None,
+                tags: utils::get_video_tags(),
             };
             runtime.block_on(controller_client.create_stream(&stream_config)).map_err(|error| {
                 gst::error_msg!(gst::ResourceError::Settings, ["Failed to create Pravega data stream: {:?}", error])

--- a/pravega-docker/docker-compose.yml
+++ b/pravega-docker/docker-compose.yml
@@ -63,7 +63,7 @@ services:
         -XX:+CrashOnOutOfMemoryError
         -XX:+HeapDumpOnOutOfMemoryError
       SERVICE_HOST_IP: segmentstore
-    image: devops-repo.isus.emc.com:8116/nautilus/nautilus-pravega:0.10.0-2918.46d007f82-1.3-W8-3-b6e25cb
+    image: pravega/pravega:latest
     links:
       - zookeeper
     networks:
@@ -75,7 +75,7 @@ services:
     restart: always
 
   segmentstore:
-    image: pravega/pravega:0.9.0
+    image: pravega/pravega:latest
     ports:
       - "12345:12345"
     command: segmentstore

--- a/pravega-docker/docker-compose.yml
+++ b/pravega-docker/docker-compose.yml
@@ -63,7 +63,7 @@ services:
         -XX:+CrashOnOutOfMemoryError
         -XX:+HeapDumpOnOutOfMemoryError
       SERVICE_HOST_IP: segmentstore
-    image: pravega/pravega:0.9.0
+    image: devops-repo.isus.emc.com:8116/nautilus/nautilus-pravega:0.10.0-2918.46d007f82-1.3-W8-3-b6e25cb
     links:
       - zookeeper
     networks:

--- a/pravega-video-server/src/main.rs
+++ b/pravega-video-server/src/main.rs
@@ -143,9 +143,9 @@ mod ui {
     #[derive(Debug, Deserialize, Serialize)]
     pub struct GetPlayerHtmlOptions {
         #[serde(rename = "scope")]
-        pub scope_name: String,
+        pub scope_name: Option<String>,
         #[serde(rename = "stream")]
-        pub stream_name: String,
+        pub stream_name: Option<String>,
         pub begin: Option<DateTime<Utc>>,
         pub end: Option<DateTime<Utc>>,
     }

--- a/pravega-video/src/utils.rs
+++ b/pravega-video/src/utils.rs
@@ -65,7 +65,7 @@ pub fn create_client_config(controller: String, keycloak_file: Option<String>) -
 }
 
 pub fn get_video_tags() -> Option<Vec<String>> {
-    Some(vec!["video".to_string()])
+    Some(vec![get_video_tag_query()])
 }
 
 pub fn get_video_tag_query() -> String {

--- a/pravega-video/src/utils.rs
+++ b/pravega-video/src/utils.rs
@@ -63,3 +63,11 @@ pub fn create_client_config(controller: String, keycloak_file: Option<String>) -
         .credentials(credential)
         .build()
 }
+
+pub fn get_video_tags() -> Option<Vec<String>> {
+    Some(vec!["video".to_string()])
+}
+
+pub fn get_video_tag_query() -> String {
+    "video".to_string()
+}


### PR DESCRIPTION
This does the following:

- Add a tag to streams we create for video. The stream tag will be "video"

- List Streams API in the Pravega Video Server only lists streams with a video tag (note, the player will still play any stream, regardless on whether it has the tag or not)

- A new List Scopes API in Pravega Video Server