### PR TITLE
Improve robustness of timestamp handling in rtsp-camera-to-pravega

### DIFF
--- a/gst-plugin-pravega/src/timestampcvt/imp.rs
+++ b/gst-plugin-pravega/src/timestampcvt/imp.rs
@@ -127,7 +127,7 @@ impl TimestampCvt {
         };
 
         // If input PTS decreases, the output PTS will be set to the previous PTS plus this amount.
-        let pts_correction_delta = 1 * MSECOND;
+        let pts_correction_delta = 15 * MSECOND;
 
         let input_pts = buffer.pts();
         if input_pts.is_some() {

--- a/python_apps/rtsp-camera-to-pravega.py
+++ b/python_apps/rtsp-camera-to-pravega.py
@@ -158,7 +158,7 @@ def main():
     parser.add_argument("--pravega-retention-days", type=float, default=-1.0)
     parser.add_argument("--pravega-retention-bytes", type=int, default=-1)
     parser.add_argument("--pravega-retention-maintenance-interval-seconds", type=int, default=0)
-    parser.add_argument("--timestamp-source", choices=["rtcp-sender-report", "local-clock"], default="rtcp-sender-report",
+    parser.add_argument("--timestamp-source", choices=["rtcp-sender-report", "local-clock"], default="local-clock",
         help="A value of rtcp-sender-report is the most accurate since the camera effectively timestamps each frame. " +
              "However for cameras that are unable to send RTSP Sender Reports or have unreliable clocks, " +
              "local-clock can be used to used, in which the time offset is calculated when the first frame is received. " +


### PR DESCRIPTION
Some RTSP cameras set timestamps unreliably. This PR makes the camera recording more robust by setting the default timestamp source to the local clock. In case PTS still goes backward, it changes the minimum frame interval from 1 ms to 15 ms so that the frame rate is reasonable.