### PR TITLE
test-integration.sh: Handle case when cargo test result JSON is on same line as application output

### DIFF
--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -62,7 +62,9 @@ cargo test --release --locked $* -- --skip ignore --nocapture --test-threads=${T
 TEST_RESULT=${PIPESTATUS[0]}
 
 if [[ "${JUNIT_OUTPUT}" != "0" ]]; then
-    cat /tmp/integration-test.log | cargo2junit | tee junit.xml
+    # Use grep to extract all JSON objects produced by cargo test anywhere in the line.
+    # This is required because sometimes such JSON objects are output on lines shared with other output.
+    cat /tmp/integration-test.log | grep -o '{ "type": .* }' | cargo2junit | tee junit.xml
 fi
 
 exit ${TEST_RESULT}


### PR DESCRIPTION
Before this change, the following integration-test.log would cause a panic in cargo2junit.

```
[2021-07-28T22:30:55.910Z] Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.{ "type": "test", "name": "pravegasrc_tests::test::test_pravegasrc_start_mode_timestamp_max", "event": "ok", "exec_time": 0.540514278 }
```

This occurred because cargo2junit did not detect the JSON object because it was not alone in the line. This PR adds a grep statement to extract the JSON from anywhere in the line.