### PR TITLE
Fix Keycloak TLS cert validation to use OS trust store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2773,7 +2773,7 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 [[package]]
 name = "pravega-client"
 version = "0.3.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=c3b92686c2890d80909e7b9ad0c79acd02717b81#c3b92686c2890d80909e7b9ad0c79acd02717b81"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=c42d55af935d8a7bf1c3460ba2a13fc280691613#c42d55af935d8a7bf1c3460ba2a13fc280691613"
 dependencies = [
  "ahash 0.6.3",
  "async-stream 0.2.1",
@@ -2812,7 +2812,7 @@ dependencies = [
 [[package]]
 name = "pravega-client-auth"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=c3b92686c2890d80909e7b9ad0c79acd02717b81#c3b92686c2890d80909e7b9ad0c79acd02717b81"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=c42d55af935d8a7bf1c3460ba2a13fc280691613#c42d55af935d8a7bf1c3460ba2a13fc280691613"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -2827,7 +2827,7 @@ dependencies = [
 [[package]]
 name = "pravega-client-channel"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=c3b92686c2890d80909e7b9ad0c79acd02717b81#c3b92686c2890d80909e7b9ad0c79acd02717b81"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=c42d55af935d8a7bf1c3460ba2a13fc280691613#c42d55af935d8a7bf1c3460ba2a13fc280691613"
 dependencies = [
  "futures-intrusive 0.4.0",
  "tokio 1.5.0",
@@ -2836,7 +2836,7 @@ dependencies = [
 [[package]]
 name = "pravega-client-config"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=c3b92686c2890d80909e7b9ad0c79acd02717b81#c3b92686c2890d80909e7b9ad0c79acd02717b81"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=c42d55af935d8a7bf1c3460ba2a13fc280691613#c42d55af935d8a7bf1c3460ba2a13fc280691613"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -2855,7 +2855,7 @@ dependencies = [
 [[package]]
 name = "pravega-client-retry"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=c3b92686c2890d80909e7b9ad0c79acd02717b81#c3b92686c2890d80909e7b9ad0c79acd02717b81"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=c42d55af935d8a7bf1c3460ba2a13fc280691613#c42d55af935d8a7bf1c3460ba2a13fc280691613"
 dependencies = [
  "snafu",
  "tokio 1.5.0",
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "pravega-client-shared"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=c3b92686c2890d80909e7b9ad0c79acd02717b81#c3b92686c2890d80909e7b9ad0c79acd02717b81"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=c42d55af935d8a7bf1c3460ba2a13fc280691613#c42d55af935d8a7bf1c3460ba2a13fc280691613"
 dependencies = [
  "async-trait",
  "bytes 0.4.12",
@@ -2889,7 +2889,7 @@ dependencies = [
 [[package]]
 name = "pravega-connection-pool"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=c3b92686c2890d80909e7b9ad0c79acd02717b81#c3b92686c2890d80909e7b9ad0c79acd02717b81"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=c42d55af935d8a7bf1c3460ba2a13fc280691613#c42d55af935d8a7bf1c3460ba2a13fc280691613"
 dependencies = [
  "async-trait",
  "dashmap 3.11.10",
@@ -2903,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "pravega-controller-client"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=c3b92686c2890d80909e7b9ad0c79acd02717b81#c3b92686c2890d80909e7b9ad0c79acd02717b81"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=c42d55af935d8a7bf1c3460ba2a13fc280691613#c42d55af935d8a7bf1c3460ba2a13fc280691613"
 dependencies = [
  "async-trait",
  "clap 2.33.3",
@@ -2977,7 +2977,7 @@ dependencies = [
 [[package]]
 name = "pravega-wire-protocol"
 version = "0.2.0"
-source = "git+https://github.com/pravega/pravega-client-rust?rev=c3b92686c2890d80909e7b9ad0c79acd02717b81#c3b92686c2890d80909e7b9ad0c79acd02717b81"
+source = "git+https://github.com/pravega/pravega-client-rust?rev=c42d55af935d8a7bf1c3460ba2a13fc280691613#c42d55af935d8a7bf1c3460ba2a13fc280691613"
 dependencies = [
  "async-trait",
  "bincode2",
@@ -3337,6 +3337,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite 0.2.6",
  "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3347,7 +3348,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg",
 ]
 
@@ -3408,6 +3408,18 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -4489,15 +4501,6 @@ checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -33,9 +33,9 @@ gst-rtsp-server = { package = "gstreamer-rtsp-server", git = "https://gitlab.fre
 gst-sdp = { package = "gstreamer-sdp", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs" }
 gstreamer-video = { git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs" }
 gtk = { git = "https://github.com/gtk-rs/gtk-rs" }
-pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
-pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
-pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
+pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
+pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
+pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
 pravega-video = { path = "../pravega-video" }
 log = "0.4"
 serde = "1"

--- a/deepstream/pravega_protocol_adapter/Cargo.toml
+++ b/deepstream/pravega_protocol_adapter/Cargo.toml
@@ -18,9 +18,9 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
-pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
-pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
+pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
+pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
+pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
 pravega-video = { path = "../../pravega-video" }
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/gst-plugin-pravega/Cargo.toml
+++ b/gst-plugin-pravega/Cargo.toml
@@ -23,9 +23,9 @@ glib = { git = "https://github.com/gtk-rs/gtk-rs" }
 gst = { package = "gstreamer", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs" }
 gst-base = { package = "gstreamer-base", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs" }
 once_cell = "1"
-pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
-pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
-pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
+pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
+pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
+pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
 pravega-video = { path = "../pravega-video" }
 
 [lib]

--- a/integration-test/Cargo.toml
+++ b/integration-test/Cargo.toml
@@ -32,9 +32,9 @@ gst-rtsp-server = { package = "gstreamer-rtsp-server", git = "https://gitlab.fre
 java-properties = "1.2"
 lazy_static = "1.4"
 once_cell = "1.7.2"
-pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
-pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
-pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
+pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
+pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
+pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
 pravega-video = { path = "../pravega-video" }
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
 tracing-subscriber = "0.2"

--- a/pravega-video-server/Cargo.toml
+++ b/pravega-video-server/Cargo.toml
@@ -24,10 +24,10 @@ futures = "0.3"
 futures-util = "0.3"
 handlebars = "3"
 hyper = "0.14"
-pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
-pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
-pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
-pravega-controller-client = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-controller-client", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
+pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
+pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
+pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
+pravega-controller-client = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-controller-client", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
 pravega-video = { path = "../pravega-video" }
 serde = "1"
 serde_derive = "1"

--- a/pravega-video/Cargo.toml
+++ b/pravega-video/Cargo.toml
@@ -22,9 +22,9 @@ chrono = "0.4"
 enumflags2 = { version = "0.6", features = ["serde"]}
 env_logger = "0.7"
 once_cell = "1"
-pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
-pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
-pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "c3b92686c2890d80909e7b9ad0c79acd02717b81" }
+pravega-client = { git = "https://github.com/pravega/pravega-client-rust", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
+pravega-client-config = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-config", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
+pravega-client-shared = { git = "https://github.com/pravega/pravega-client-rust", package = "pravega-client-shared", rev = "c42d55af935d8a7bf1c3460ba2a13fc280691613" }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 

--- a/scripts/videotestsrc-to-pravega-eaglemonk.sh
+++ b/scripts/videotestsrc-to-pravega-eaglemonk.sh
@@ -15,7 +15,7 @@
 set -ex
 ROOT_DIR=$(readlink -f $(dirname $0)/..)
 pushd ${ROOT_DIR}/gst-plugin-pravega
-cargo build --locked
+cargo build
 ls -lh ${ROOT_DIR}/target/debug/*.so
 export GST_PLUGIN_PATH=${ROOT_DIR}/target/debug:${GST_PLUGIN_PATH}
 # log level can be INFO, DEBUG, or LOG (verbose)

--- a/scripts/videotestsrc-to-pravega-eaglemonk.sh
+++ b/scripts/videotestsrc-to-pravega-eaglemonk.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# TODO: For an unknown reason, the timestamp appears to progress faster than real time.
+
+set -ex
+ROOT_DIR=$(readlink -f $(dirname $0)/..)
+pushd ${ROOT_DIR}/gst-plugin-pravega
+cargo build --locked
+ls -lh ${ROOT_DIR}/target/debug/*.so
+export GST_PLUGIN_PATH=${ROOT_DIR}/target/debug:${GST_PLUGIN_PATH}
+# log level can be INFO, DEBUG, or LOG (verbose)
+export GST_DEBUG=pravegasink:INFO,basesink:INFO
+export RUST_BACKTRACE=1
+export pravega_client_tls_cert_path=/etc/ssl/certs/ca-certificates.crt
+PRAVEGA_CONTROLLER_URI=${PRAVEGA_CONTROLLER_URI:-tls://pravega-controller.kubespray.nautilus-platform-dev.com:443}
+PRAVEGA_SCOPE=${PRAVEGA_SCOPE:-examples}
+PRAVEGA_STREAM=${PRAVEGA_STREAM:-test1}
+ALLOW_CREATE_SCOPE=${ALLOW_CREATE_SCOPE:-false}
+SIZE_SEC=10
+FPS=30
+
+NAMESPACE=${PRAVEGA_SCOPE}
+KEYCLOAK_SERVICE_ACCOUNT_FILE=${HOME}/keycloak.json
+kubectl config use-context eaglemonk
+kubectl get secret ${NAMESPACE}-pravega -n ${NAMESPACE} -o jsonpath="{.data.keycloak\.json}" | base64 -d > ${KEYCLOAK_SERVICE_ACCOUNT_FILE}
+
+gst-launch-1.0 \
+-v \
+videotestsrc name=src is-live=false do-timestamp=true num-buffers=$(($SIZE_SEC*$FPS)) \
+! "video/x-raw,format=YUY2,width=1920,height=1280,framerate=${FPS}/1" \
+! videoconvert \
+! clockoverlay "font-desc=Sans 48px" "time-format=%F %T" shaded-background=true \
+! timeoverlay valignment=bottom "font-desc=Sans 48px" shaded-background=true \
+! videoconvert \
+! x264enc key-int-max=${FPS} speed-preset=ultrafast bitrate=2000 \
+! mpegtsmux alignment=-1 \
+! pravegasink \
+  stream=${PRAVEGA_SCOPE}/${PRAVEGA_STREAM} \
+  controller=${PRAVEGA_CONTROLLER_URI} \
+  keycloak-file=${KEYCLOAK_SERVICE_ACCOUNT_FILE} \
+  seal=false \
+  sync=false \
+  allow-create-scope=${ALLOW_CREATE_SCOPE}

--- a/scripts/videotestsrc-to-pravega-keycloak.sh
+++ b/scripts/videotestsrc-to-pravega-keycloak.sh
@@ -31,7 +31,6 @@ FPS=30
 
 NAMESPACE=${PRAVEGA_SCOPE}
 KEYCLOAK_SERVICE_ACCOUNT_FILE=${HOME}/keycloak.json
-kubectl config use-context eaglemonk
 kubectl get secret ${NAMESPACE}-pravega -n ${NAMESPACE} -o jsonpath="{.data.keycloak\.json}" | base64 -d > ${KEYCLOAK_SERVICE_ACCOUNT_FILE}
 
 gst-launch-1.0 \


### PR DESCRIPTION
This updates the Pravega client to https://github.com/pravega/pravega-client-rust/commit/c42d55af935d8a7bf1c3460ba2a13fc280691613. 