### PR TITLE
Revert "Check for Needed Static Files"

### DIFF
--- a/pravega-video-server/src/main.rs
+++ b/pravega-video-server/src/main.rs
@@ -11,8 +11,6 @@
 use clap::Clap;
 use pravega_client::client_factory::ClientFactory;
 use pravega_video::utils;
-use std::path::Path;
-
 use tracing_subscriber::fmt::format::FmtSpan;
 #[allow(unused_imports)]
 use tracing::{error, info, info_span, warn, trace, event, Level, span};
@@ -46,7 +44,6 @@ fn main() {
     info!("opts={:?}", opts);
 
     let static_dir_name = format!("{}/static", opts.resource_dir);
-    ensure_extra_files(opts.resource_dir.clone());
 
     // Let Pravega ClientFactory create the Tokio runtime. It will also be used by Warp.
 
@@ -71,17 +68,6 @@ fn main() {
         warp::serve(routes).run(([0, 0, 0, 0], 3030)).await;
     })
 }
-
-fn ensure_extra_files(resource_dir: String) {
-    for file in ["static/gap-5s.mp4", "static/hls-js.js", "templates/player.html"] {
-        let path = format!("{}/{}", resource_dir, file);
-        if ! Path::new(&path).exists() {
-            error!("Missing file to run pravega-video-server: {}", file);
-            std::process::exit(1);
-        }
-    }
-}
-
 mod filters {
     use super::handlers;
     use super::models::{Db, GetMediaSegmentOptions, GetM3u8PlaylistOptions};


### PR DESCRIPTION
Reverts pravega/gstreamer-pravega#109 that fails due to a Rust compile error. Investigation is in progress.