### PR TITLE
[STRM-11119] pravegatc failure recovery now skips potential input stream errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 *.log
 *.mp4
 *.nfs*
+*.pem
 *.tgz
 *.ts
 !/pravega-video-server/resources/static/*.ts

--- a/integration-test/src/failure_recovery_tests.rs
+++ b/integration-test/src/failure_recovery_tests.rs
@@ -107,7 +107,7 @@ mod test {
         let resume_from_pts: PravegaTimestamp = first_pts_full + 30510 * MSECOND;
         let pipeline_description = format!("\
             pravegasrc {pravega_plugin_properties} \
-              start-mode=timestamp \
+              start-mode=timestamp-exact \
               start-timestamp={resume_from_pts} \
             ! identity name=before_decode silent=false \
             ! decodebin \


### PR DESCRIPTION
To make failure recovery more robust, this PR updates **pravegatc** and **pravegasrc**. If pipeline recovery is attempted more than once from the same PTS, it is assumed that the input stream is defective, and subsequent recovery attempts will skip over increasing amounts of data. 

The start-mode parameter of **pravegasrc** now has two variations of timestamp values. The "timestamp-exact" enum causes the segment to start at the specified time. The "timestamp" enum causes the segment to start at the time in the index record. During recovery, **pravegatc** will use "timestamp-exact" mode first, but if that fails and recovery starts from the same location again, then "timestamp" mode will be used with an increasing timestamp.