### PR TITLE
Change docker/build-gstreamer/compile to specify exact build options required for each project

### DIFF
--- a/docker/build-gstreamer/compile
+++ b/docker/build-gstreamer/compile
@@ -14,16 +14,30 @@ set -ex
 
 for repo in gstreamer libnice gst-plugins-base gst-plugins-bad gst-plugins-good gst-plugins-ugly gst-libav gst-rtsp-server; do
   pushd $repo
-  # TODO: Hack: `-D gupnp=disabled` is for libnice, because libgupnp-igd causes memory leaks
+
+  opts="-D prefix=/usr"
+
+  if [[ $repo == "libnice" ]]; then
+    # TODO: Hack: `-D gupnp=disabled` is for libnice, because libgupnp-igd causes memory leaks
+    opts="$opts -D gupnp=disabled"
+  elif [[ $repo == "gst-plugins-base" ]]; then
+    opts="$opts -D gl=disabled"
+  elif [[ $repo == "gst-plugins-bad" ]]; then
+    opts="$opts -D gl=disabled -D msdk=enabled"
+  fi
+
   if [[ $DEBUG == 'true' ]]; then
     if [[ $OPTIMIZATIONS == 'true' ]]; then
-      meson build -D prefix=/usr -D gupnp=disabled -D msdk=enabled -D with_x11=no -D gl=disabled -D debug=true -D optimization=2
+      opts="$opts -D debug=true -D optimization=2"
     else
-      meson build -D prefix=/usr -D gupnp=disabled -D msdk=enabled -D with_x11=no -D gl=disabled -D debug=true
+      opts="$opts -D debug=true"
     fi
   else
-    meson build -D prefix=/usr -D gupnp=disabled -D msdk=enabled -D with_x11=no -D gl=disabled -D debug=false -D optimization=3 -D b_lto=true -D buildtype=release
+    opts="$opts -D debug=false -D optimization=3 -D b_lto=true -D buildtype=release"
   fi
+
+  meson build $opts
+
   # This is needed for other plugins to be built properly
   ninja -C build install
   # This is where we'll grab build artifacts from


### PR DESCRIPTION
This is required because meson now throws an error on unknown options.
See https://github.com/mesonbuild/meson/issues/932. 
Camera Recorder Pipeline and Pravega Video Server have been tested successfully.
