### PR TITLE
Add option to timestampcvt to start timestamp at fixed time

### DIFF
--- a/gst-plugin-pravega/src/pravegasink/imp.rs
+++ b/gst-plugin-pravega/src/pravegasink/imp.rs
@@ -744,7 +744,7 @@ impl BaseSinkImpl for PravegaSink {
             let config = utils::create_client_config(controller, keycloak_file).map_err(|error| {
                 gst::error_msg!(gst::ResourceError::Settings, ["Failed to create Pravega client config: {}", error])
             })?;
-            gst_debug!(CAT, obj: element, "start: config={:?}", config);
+            gst_trace!(CAT, obj: element, "start: config={:?}", config);
             gst_info!(CAT, obj: element, "start: controller_uri={}:{}", config.controller_uri.domain_name(), config.controller_uri.port());
             gst_info!(CAT, obj: element, "start: is_tls_enabled={}", config.is_tls_enabled);
             gst_info!(CAT, obj: element, "start: is_auth_enabled={}", config.is_auth_enabled);

--- a/gst-plugin-pravega/src/pravegasink/imp.rs
+++ b/gst-plugin-pravega/src/pravegasink/imp.rs
@@ -61,7 +61,7 @@ pub enum TimestampMode {
     #[genum(
         name = "(DEPRECATED) Pipeline uses the realtime clock which provides nanoseconds \
                 since the Unix epoch 1970-01-01 00:00:00 UTC, not including leap seconds. \
-                This mode is deprecated. Instead, use the timestampcvt element with input-timestamp-mode=relative.",
+                This mode is deprecated. Instead, use the timestampcvt element with input-timestamp-mode=start-at-current-time.",
         nick = "realtime-clock"
     )]
     RealtimeClock = 0,

--- a/gst-plugin-pravega/src/pravegasrc/imp.rs
+++ b/gst-plugin-pravega/src/pravegasrc/imp.rs
@@ -573,7 +573,7 @@ impl BaseSrcImpl for PravegaSrc {
             let config = utils::create_client_config(controller, keycloak_file).map_err(|error| {
                 gst::error_msg!(gst::ResourceError::Settings, ["Failed to create Pravega client config: {}", error])
             })?;
-            gst_debug!(CAT, obj: element, "start: config={:?}", config);
+            gst_trace!(CAT, obj: element, "start: config={:?}", config);
             gst_info!(CAT, obj: element, "start: controller_uri={}:{}", config.controller_uri.domain_name(), config.controller_uri.port());
             gst_info!(CAT, obj: element, "start: is_tls_enabled={}", config.is_tls_enabled);
             gst_info!(CAT, obj: element, "start: is_auth_enabled={}", config.is_auth_enabled);

--- a/gst-plugin-pravega/src/timestampcvt/imp.rs
+++ b/gst-plugin-pravega/src/timestampcvt/imp.rs
@@ -263,17 +263,14 @@ impl TimestampCvt {
     }
 
     fn sink_query(&self, pad: &gst::Pad, _element: &super::TimestampCvt, query: &mut gst::QueryRef) -> bool {
-        gst_debug!(CAT, obj: pad, "sink_query={:?}", query);
         self.srcpad.peer_query(query)
     }
 
     fn src_event(&self, pad: &gst::Pad, _element: &super::TimestampCvt, event: gst::Event) -> bool {
-        gst_debug!(CAT, obj: pad, "src_event={:?}", event);
         self.sinkpad.push_event(event)
     }
 
     fn src_query(&self, pad: &gst::Pad, _element: &super::TimestampCvt, query: &mut gst::QueryRef) -> bool {
-        gst_debug!(CAT, obj: pad, "src_query={:?}", query);
         self.sinkpad.peer_query(query)
     }
 }

--- a/gst-plugin-pravega/src/timestampcvt/imp.rs
+++ b/gst-plugin-pravega/src/timestampcvt/imp.rs
@@ -246,7 +246,7 @@ impl TimestampCvt {
     }
 
     fn sink_event(&self, pad: &gst::Pad, _element: &super::TimestampCvt, event: gst::Event) -> bool {
-        gst_info!(CAT, obj: pad, "sink_event: event={:?}", event);
+        gst_debug!(CAT, obj: pad, "sink_event: event={:?}", event);
         match event.view() {
             gst::EventView::Segment(segment) => {
                 // Segments from a file will have a start and end timestamp which will prevent
@@ -262,15 +262,15 @@ impl TimestampCvt {
         }        
     }
 
-    fn sink_query(&self, pad: &gst::Pad, _element: &super::TimestampCvt, query: &mut gst::QueryRef) -> bool {
+    fn sink_query(&self, _pad: &gst::Pad, _element: &super::TimestampCvt, query: &mut gst::QueryRef) -> bool {
         self.srcpad.peer_query(query)
     }
 
-    fn src_event(&self, pad: &gst::Pad, _element: &super::TimestampCvt, event: gst::Event) -> bool {
+    fn src_event(&self, _pad: &gst::Pad, _element: &super::TimestampCvt, event: gst::Event) -> bool {
         self.sinkpad.push_event(event)
     }
 
-    fn src_query(&self, pad: &gst::Pad, _element: &super::TimestampCvt, query: &mut gst::QueryRef) -> bool {
+    fn src_query(&self, _pad: &gst::Pad, _element: &super::TimestampCvt, query: &mut gst::QueryRef) -> bool {
         self.sinkpad.peer_query(query)
     }
 }

--- a/gst-plugin-pravega/src/timestampcvt/imp.rs
+++ b/gst-plugin-pravega/src/timestampcvt/imp.rs
@@ -252,10 +252,10 @@ impl TimestampCvt {
                 // Segments from a file will have a start and end timestamp which will prevent
                 // playback after adjusting the PTS.
                 // To avoid this, we replace the segment with an empty one.
-                gst_info!(CAT, obj: pad, "sink_event: segment={:?}", segment);
+                gst_debug!(CAT, obj: pad, "sink_event: segment={:?}", segment);
                 let new_segment = gst::FormattedSegment::<gst::ClockTime>::new();
                 let new_event = gst::event::Segment::new(new_segment.as_ref());
-                gst_info!(CAT, obj: pad, "sink_event: new_segment={:?}", new_segment);
+                gst_debug!(CAT, obj: pad, "sink_event: new_segment={:?}", new_segment);
                 self.srcpad.push_event(new_event)
             }
             _ => self.srcpad.push_event(event)
@@ -263,17 +263,17 @@ impl TimestampCvt {
     }
 
     fn sink_query(&self, pad: &gst::Pad, _element: &super::TimestampCvt, query: &mut gst::QueryRef) -> bool {
-        gst_info!(CAT, obj: pad, "sink_query={:?}", query);
+        gst_debug!(CAT, obj: pad, "sink_query={:?}", query);
         self.srcpad.peer_query(query)
     }
 
     fn src_event(&self, pad: &gst::Pad, _element: &super::TimestampCvt, event: gst::Event) -> bool {
-        gst_info!(CAT, obj: pad, "src_event={:?}", event);
+        gst_debug!(CAT, obj: pad, "src_event={:?}", event);
         self.sinkpad.push_event(event)
     }
 
     fn src_query(&self, pad: &gst::Pad, _element: &super::TimestampCvt, query: &mut gst::QueryRef) -> bool {
-        gst_info!(CAT, obj: pad, "src_query={:?}", query);
+        gst_debug!(CAT, obj: pad, "src_query={:?}", query);
         self.sinkpad.peer_query(query)
     }
 }

--- a/gst-plugin-pravega/tests/timestampcvt.rs
+++ b/gst-plugin-pravega/tests/timestampcvt.rs
@@ -76,7 +76,7 @@ fn test_timestampcvt_start_at_zero() {
     println!("test_timestampcvt_start_at_zero: BEGIN");
     init();
     let filter = gst::ElementFactory::make("timestampcvt", None).unwrap();
-    filter.set_property_from_str("input-timestamp-mode", "relative");
+    filter.set_property_from_str("input-timestamp-mode", "start-at-current-time");
     let mut h = gst_check::Harness::with_element(&filter, Some("sink"), Some("src"));
     h.set_src_caps_str("data");
     h.set_sink_caps_str("data");

--- a/gst-plugin-pravega/tests/timestampcvt.rs
+++ b/gst-plugin-pravega/tests/timestampcvt.rs
@@ -12,6 +12,7 @@ use gst::ClockTime;
 use gst::prelude::*;
 use gstpravega::utils::{pravega_to_clocktime, now_ntp_clocktime};
 use pravega_video::timestamp::PravegaTimestamp;
+use std::convert::TryFrom;
 
 fn init() {
     use std::sync::Once;
@@ -91,6 +92,27 @@ fn test_timestampcvt_start_at_zero() {
     push_and_validate(&mut h, 2000 * gst::MSECOND, Some(t0 + 2000 * gst::MSECOND));
 
     println!("test_timestampcvt_start_at_zero: END");
+}
+
+#[test]
+fn test_timestampcvt_start_fixed_time() {
+    println!("test_timestampcvt_start_fixed_time: BEGIN");
+    init();
+    let start_utc = "2001-02-03T04:00:00.000Z".to_owned();
+    let start_timestamp = PravegaTimestamp::try_from(Some(start_utc.clone())).unwrap();
+    let filter = gst::ElementFactory::make("timestampcvt", None).unwrap();
+    filter.set_property_from_str("input-timestamp-mode", "start-at-fixed-time");
+    filter.set_property_from_str("start-utc", &start_utc[..]);
+    let mut h = gst_check::Harness::with_element(&filter, Some("sink"), Some("src"));
+    h.set_src_caps_str("data");
+    h.set_sink_caps_str("data");
+    h.play();
+
+    let expected_t0 = pravega_to_clocktime(start_timestamp);
+    push_and_validate(&mut h, 10000 * gst::MSECOND, Some(expected_t0));
+    push_and_validate(&mut h, 10100 * gst::MSECOND, Some(expected_t0 + 100 * gst::MSECOND));
+
+    println!("test_timestampcvt_start_fixed_time: END");
 }
 
 fn push_and_validate(harness: &mut gst_check::Harness, input_pts: ClockTime, expected_output_pts: Option<ClockTime>) {

--- a/integration-test/src/file_import_tests.rs
+++ b/integration-test/src/file_import_tests.rs
@@ -28,6 +28,7 @@ mod test {
         #[case] container_format: ContainerFormat) {
         let test_config = get_test_config();
         info!("test_config={:?}", test_config);
+        info!("description={:?}", description);
         let mp4_filename = "/tmp/timestampcvt_test1.mp4";
         let start_utc = "2001-02-03T04:00:00.000Z".to_owned();
         gst_init();

--- a/integration-test/src/file_import_tests.rs
+++ b/integration-test/src/file_import_tests.rs
@@ -1,0 +1,113 @@
+//
+// Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#[cfg(test)]
+mod test {
+    use pravega_video::timestamp::MSECOND;
+    use rstest::rstest;
+    #[allow(unused_imports)]
+    use tracing::{error, info, debug};
+    use uuid::Uuid;
+    use crate::*;
+    use crate::utils::*;
+
+    #[rstest]
+    #[case(
+        "default",
+        VideoEncoder::H264(H264EncoderConfigBuilder::default().key_int_max_frames(30).build().unwrap()),
+        ContainerFormat::Mp4(Mp4MuxConfigBuilder::default().fragment_duration(1 * MSECOND).build().unwrap()),
+    )]
+    fn file_import_test(#[case] description: &str, #[case] video_encoder: VideoEncoder,
+        #[case] container_format: ContainerFormat) {
+        let test_config = get_test_config();
+        info!("test_config={:?}", test_config);
+        let mp4_filename = "/tmp/timestampcvt_test1.mp4";
+        let start_utc = "2001-02-03T04:00:00.000Z".to_owned();
+        gst_init();
+        let stream_name = &format!("test-{}-{}", test_config.test_id, Uuid::new_v4())[..];
+        let video_encoder_pipeline = video_encoder.pipeline();
+        let container_pipeline = container_format.pipeline();
+
+        info!("#### Write MP4 file");
+        let pipeline_description = format!("\
+            videotestsrc name=src num-buffers=300 \
+            ! video/x-raw,width=160,height=120,framerate=30/1 \
+            ! videoconvert \
+            ! x264enc key-int-max=60 tune=zerolatency \
+            ! mp4mux \
+            ! identity silent=false \
+            ! filesink location={mp4_filename}",
+            mp4_filename = mp4_filename,
+        );        
+        launch_pipeline(&pipeline_description).unwrap();
+
+        info!("#### Read MP4 file");
+        let pipeline_description = format!("\
+            uridecodebin name=src uri=file://{mp4_filename} \
+            ! timestampcvt input-timestamp-mode=start-at-fixed-time start-utc={start_utc} \
+            ! identity silent=false \
+            ! appsink name=sink sync=false",
+            mp4_filename = mp4_filename,
+            start_utc = start_utc,
+        );
+        let summary_read_mp4 = launch_pipeline_and_get_summary(&pipeline_description).unwrap();
+        debug!("summary_read_mp4={}", summary_read_mp4);
+
+        info!("#### Transcode MP4 file");
+        let pipeline_description = format!("\
+            uridecodebin name=src uri=file://{mp4_filename} \
+            ! timestampcvt input-timestamp-mode=start-at-fixed-time start-utc={start_utc} \
+            ! identity silent=false \
+            ! {video_encoder_pipeline} \
+            ! {container_pipeline} \
+            ! appsink name=sink sync=false",
+            mp4_filename = mp4_filename,
+            start_utc = start_utc,
+            video_encoder_pipeline = video_encoder_pipeline,
+            container_pipeline = container_pipeline,
+        );
+        let summary_transcode = launch_pipeline_and_get_summary(&pipeline_description).unwrap();
+        debug!("summary_transcode={}", summary_transcode);
+
+        info!("#### Copy MP4 file to Pravega");
+        let pipeline_description = format!("\
+            uridecodebin name=src uri=file://{mp4_filename} \
+            ! timestampcvt input-timestamp-mode=start-at-fixed-time start-utc={start_utc} \
+            ! identity silent=false \
+            ! {video_encoder_pipeline} \
+            ! {container_pipeline} \
+            ! pravegasink {pravega_plugin_properties} seal=true timestamp-mode=tai sync=false",
+            pravega_plugin_properties = test_config.pravega_plugin_properties(stream_name),
+            mp4_filename = mp4_filename,
+            start_utc = start_utc,
+            video_encoder_pipeline = video_encoder_pipeline,
+            container_pipeline = container_pipeline,
+        );
+        launch_pipeline(&pipeline_description).unwrap();
+
+        info!("#### Read from Pravega with decoding");
+        let pipeline_description = format!(
+            "pravegasrc {pravega_plugin_properties} \
+              start-mode=earliest \
+            ! decodebin \
+            ! identity silent=false \
+            ! appsink name=sink sync=false",
+            pravega_plugin_properties = test_config.pravega_plugin_properties(stream_name),
+        );
+        let summary_read_pravega = launch_pipeline_and_get_summary(&pipeline_description).unwrap();
+        summary_read_pravega.dump("summary_read_pravega");
+        info!("summary_read_mp4=    {}", summary_read_mp4);
+        info!("summary_read_pravega={}", summary_read_pravega);
+        assert_timestamp_eq("first_pts", summary_read_pravega.first_pts(), summary_read_mp4.first_pts());
+        assert_timestamp_eq("last_valid_pts", summary_read_pravega.last_valid_pts(), summary_read_mp4.last_valid_pts());
+        assert_between_u64("corrupted_buffer_count", summary_read_pravega.corrupted_buffer_count(), 0, 2);
+        info!("#### END");
+    }
+}

--- a/integration-test/src/lib.rs
+++ b/integration-test/src/lib.rs
@@ -12,6 +12,7 @@
 
 mod extreme_tests;
 mod failure_recovery_tests;
+mod file_import_tests;
 mod hls_tests;
 mod pravegasrc_seek_tests;
 mod pravegasrc_tests;

--- a/python_apps/rtsp-camera-to-pravega.py
+++ b/python_apps/rtsp-camera-to-pravega.py
@@ -237,7 +237,7 @@ def main():
         if args.timestamp_source == "rtcp-sender-report":
             timestampcvt.set_property("input-timestamp-mode", "ntp")
         else:
-            timestampcvt.set_property("input-timestamp-mode", "relative")
+            timestampcvt.set_property("input-timestamp-mode", "start-at-current-time")
     pravegasink = pipeline.get_by_name("pravegasink")
     if pravegasink:
         pravegasink.set_property("allow-create-scope", args.allow_create_scope)

--- a/python_apps/video_file_to_pravega.py
+++ b/python_apps/video_file_to_pravega.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+
+#
+# Import a video file to a Pravega stream.
+#
+
+import configargparse as argparse
+import ctypes
+import datetime
+import distutils.util
+import logging
+import os
+import signal
+import sys
+import time
+import traceback
+from gstpravega import bus_call
+
+
+import gi
+gi.require_version("Gst", "1.0")
+from gi.repository import GObject, Gst
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Import a video file to a Pravega stream. This transcodes the video to an appropriate format.",
+        auto_env_var_prefix="")
+    # Note that below arguments can be passed through the environment such as PRAVEGA_CONTROLLER_URI.
+    parser.add_argument("--bitrate-kilobytes-per-sec", type=float, default=500)
+    parser.add_argument("--fragment-duration-ms", type=int, default=1)
+    parser.add_argument("--keycloak-service-account-file")
+    parser.add_argument("--log-level", type=int, default=logging.INFO, help="10=DEBUG,20=INFO")
+    parser.add_argument("--pravega-controller-uri", default="tcp://127.0.0.1:9090")
+    parser.add_argument("--pravega-scope", required=True)
+    parser.add_argument("--pravega-stream", required=True)
+    parser.add_argument("--pravega-buffer-size", type=int, default=1024, help="Pravega writer buffer size in bytes")
+    parser.add_argument("--source-uri", required=True,
+                        help="URI of the file to import")
+    parser.add_argument("--start-utc", required=True,
+                        help="The first frame in the video file will be recorded with this timestamp in RFC 3339 format (2021-12-28T23:41:45.691Z).")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=args.log_level, format="%(asctime)s %(levelname)-7s %(message)s")
+    logging.Formatter.formatTime = (lambda self, record, datefmt: datetime.datetime.fromtimestamp(record.created, datetime.timezone.utc).astimezone().isoformat())
+    logging.info(f"{parser.prog}: BEGIN")
+
+    # Set default GStreamer logging.
+    if not "GST_DEBUG" in os.environ:
+        os.environ["GST_DEBUG"] = ("WARNING,timestampcvt:INFO,pravegasink:DEBUG")
+
+    # Set default logging for pravega-video, which sets a Rust tracing subscriber used by the Pravega Rust Client.
+    if not "PRAVEGA_VIDEO_LOG" in os.environ:
+        os.environ["PRAVEGA_VIDEO_LOG"] = "info"
+
+    # Print configuration parameters.
+    for arg in vars(args):
+        logging.info("argument: %s: %s" % (arg, getattr(args, arg)))
+
+    # Standard GStreamer initialization.
+    Gst.init(None)
+    logging.info(Gst.version_string())
+
+    # Create GStreamer pipeline.
+
+    pipeline_description = (
+        f"uridecodebin name=src\n" +
+        f"   ! queue\n" +
+        f"   ! timestampcvt name=timestampcvt\n" +
+        f"   ! videoconvert\n" +
+        f"   ! nvvideoconvert\n" +
+        f"   ! queue\n" +
+        f"   ! x264enc name=x264enc\n"
+        f"   ! queue\n" +
+        f"   ! h264parse\n" +
+        f"   ! mp4mux name=mp4mux\n" +
+        f"   ! fragmp4pay\n" +
+        f"   ! pravegasink name=pravegasink\n"
+    )
+    logging.info("Creating pipeline:\n" +  pipeline_description)
+    pipeline = Gst.parse_launch(pipeline_description)
+    pipelines += [pipeline]
+
+    # This will cause property changes to be logged as PROPERTY_NOTIFY messages.
+    pipeline.add_property_deep_notify_watch(None, True)
+
+    src = pipeline.get_by_name("src")
+    if src:
+        src.set_property("uri", args.source_uri)
+    timestampcvt = pipeline.get_by_name("timestampcvt")
+    if timestampcvt:
+        timestampcvt.set_property("input-timestamp-mode", "start-at-fixed-time")
+        timestampcvt.set_property("start-utc", args.start_utc)
+    x264enc = pipeline.get_by_name("x264enc")
+    if x264enc:
+        x264enc.set_property("bitrate", int(args.bitrate_kilobytes_per_sec * 8))
+        x264enc.set_property("key-int-max", 30)
+        x264enc.set_property("tune", "zerolatency")
+    mp4mux = pipeline.get_by_name("mp4mux")
+    if mp4mux:
+        mp4mux.set_property("streamable", True)
+        mp4mux.set_property("fragment-duration", args.fragment_duration_ms)
+    pravegasink = pipeline.get_by_name("pravegasink")
+    if pravegasink:
+        pravegasink.set_property("controller", args.pravega_controller_uri)
+        if args.keycloak_service_account_file:
+            pravegasink.set_property("keycloak-file", args.keycloak_service_account_file)
+        pravegasink.set_property("stream", "%s/%s" % (args.pravega_scope, args.pravega_stream))
+        # Always write to Pravega immediately regardless of PTS
+        pravegasink.set_property("sync", False)
+        pravegasink.set_property("buffer-size", args.pravega_buffer_size)
+        pravegasink.set_property("timestamp-mode", "tai")
+
+    # Create an event loop and feed GStreamer bus messages to it.
+    loop = GObject.MainLoop()
+    bus = pipeline.get_bus()
+    bus.add_signal_watch()
+    bus.connect("message", bus_call, loop)
+
+    def shutdown_handler(signum, frame):
+        logging.info("Shutting down due to received signal %s" % signum)
+        loop.quit()
+
+    signal.signal(signal.SIGINT, shutdown_handler)
+    signal.signal(signal.SIGTERM, shutdown_handler)
+
+    # Start play back and listen to events.
+    logging.info("Starting pipelines")
+    for p in pipelines: p.set_state(Gst.State.PLAYING)
+    try:
+        loop.run()
+    except:
+        logging.error(traceback.format_exc())
+        # Cleanup GStreamer elements.
+        pipeline.set_state(Gst.State.NULL)
+        raise
+
+    logging.info("Stopping pipelines")
+    for p in pipelines: p.set_state(Gst.State.NULL)
+    logging.info(f"{parser.prog}: END")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Element `timestampcvt` parameter `input-timestamp-mode` now has option `start-at-fixed-time` to make the PTS of the first buffer equal to a fixed time. This is useful when importing video from a file source.
Unit and integration tests have been updated.

Note that the option `relative` has been renamed to `start-at-current-time`.

```
scripts/test-all.sh
...
test-all.sh: All tests completed successfully.
```