### PR TITLE
Update base image to ubuntu:22.04

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,7 +2529,7 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.63"
+version = "0.9.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2356,9 +2356,9 @@ checksum = "a2983372caf4480544083767bf2d27defafe32af49ab4df3a0b7fc90793a3664"
 
 [[package]]
 name = "native-tls"
-version = "0.2.7"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2509,16 +2509,28 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.34"
+version = "0.10.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
+checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
+ "openssl-macros",
  "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2531,7 +2543,7 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 name = "openssl-sys"
 version = "0.9.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
+checksum = "9d5fd19fb3e0a8191c1e34935718976a3e70c112ab9a24af6d7cadccd9d90bc0"
 dependencies = [
  "autocfg",
  "cc",

--- a/deepstream/deepstream-dev-pod.Dockerfile
+++ b/deepstream/deepstream-dev-pod.Dockerfile
@@ -18,6 +18,8 @@ FROM ${FROM_IMAGE}
 COPY docker/ca-certificates /usr/local/share/ca-certificates/
 RUN update-ca-certificates
 
+RUN apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         curl \

--- a/deepstream/pravega-deepstream.Dockerfile
+++ b/deepstream/pravega-deepstream.Dockerfile
@@ -17,6 +17,8 @@ FROM ${FROM_IMAGE} as builder-base
 COPY docker/ca-certificates /usr/local/share/ca-certificates/
 RUN update-ca-certificates
 
+RUN apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+
 # Install Python Bindings for DeepStream.
 
 RUN apt-get update && \

--- a/docker/build-release.sh
+++ b/docker/build-release.sh
@@ -16,7 +16,7 @@ ROOT_DIR=$(readlink -f $(dirname $0)/..)
 GSTREAMER_CHECKOUT=${GSTREAMER_CHECKOUT:-1.18.5}
 RUST_JOBS=${RUST_JOBS:-4}
 DOCKER_REPOSITORY=${DOCKER_REPOSITORY}
-FROM_IMAGE=ubuntu:22.04
+FROM_IMAGE=ubuntu:21.04
 
 # Make sure to always have fresh base image.
 if [[ "${PULL_BASE}" != "0" ]]; then

--- a/docker/build-release.sh
+++ b/docker/build-release.sh
@@ -16,7 +16,7 @@ ROOT_DIR=$(readlink -f $(dirname $0)/..)
 GSTREAMER_CHECKOUT=${GSTREAMER_CHECKOUT:-1.18.5}
 RUST_JOBS=${RUST_JOBS:-4}
 DOCKER_REPOSITORY=${DOCKER_REPOSITORY}
-FROM_IMAGE=ubuntu:21.04
+FROM_IMAGE=ubuntu:22.04
 
 # Make sure to always have fresh base image.
 if [[ "${PULL_BASE}" != "0" ]]; then

--- a/docker/install-prod-dependencies
+++ b/docker/install-prod-dependencies
@@ -53,7 +53,7 @@ apt-get install -y --no-install-recommends \
   libfaad2 \
   libfdk-aac2 \
   libflite1 \
-  libfluidsynth2 \
+  libfluidsynth3 \
   libgbm1 \
   libgcrypt20 \
   libgl1 \
@@ -62,7 +62,7 @@ apt-get install -y --no-install-recommends \
   libglib2.0-0 \
   libgme0 \
   libgmp10 \
-  libgsl25 \
+  libgsl27 \
   libgsm1 \
   libgudev-1.0-0 \
   libharfbuzz-icu0 \
@@ -99,7 +99,7 @@ apt-get install -y --no-install-recommends \
   libspeex1 \
   libsrt1.4-openssl \
   libsrtp2-1 \
-  libssl1.1 \
+  libssl3 \
   libtag1v5 \
   libtheora0 \
   libtwolame0 \
@@ -109,20 +109,20 @@ apt-get install -y --no-install-recommends \
   libvo-aacenc0 \
   libvo-amrwbenc0 \
   libvorbis0a \
-  libvpx6 \
+  libvpx7 \
   libvulkan1 \
   libwavpack1 \
   libwayland-client0 \
   libwayland-egl1 \
   libwayland-server0 \
-  libwebp6 \
+  libwebp7 \
   libwebpdemux2 \
   libwebpmux3 \
   libwebrtc-audio-processing1 \
   libwildmidi2 \
   libwoff1 \
-  libx264-160 \
-  libx265-192 \
+  libx264-163 \
+  libx265-199 \
   libxkbcommon0 \
   libxslt1.1 \
   libzbar0 \

--- a/docker/install-prod-dependencies
+++ b/docker/install-prod-dependencies
@@ -29,7 +29,7 @@ apt-get install -y --no-install-recommends \
   libgtk-3-0 \
   liba52-0.7.4 \
   libaa1 \
-  libaom0 \
+  libaom3 \
   libass9 \
   libavcodec58 \
   libavfilter7 \

--- a/docker/pravega.Dockerfile
+++ b/docker/pravega.Dockerfile
@@ -76,8 +76,9 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN set -eux; \
     rustArch="x86_64-unknown-linux-gnu"; \
     url="https://static.rust-lang.org/rustup/archive/1.23.1/${rustArch}/rustup-init"; \
-    wget --quiet "$url"; \
-    chmod +x rustup-init; \
+    wget "$url"
+
+RUN chmod +x rustup-init; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \

--- a/docker/pravega.Dockerfile
+++ b/docker/pravega.Dockerfile
@@ -76,7 +76,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN set -eux; \
     rustArch="x86_64-unknown-linux-gnu"; \
     url="https://static.rust-lang.org/rustup/archive/1.23.1/${rustArch}/rustup-init"; \
-    wget "$url"
+    wget --ca-directory=/usr/local/share/ca-certificates/ "$url"
 
 RUN chmod +x rustup-init; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION --default-host ${rustArch}; \

--- a/docker/pravega.Dockerfile
+++ b/docker/pravega.Dockerfile
@@ -74,6 +74,8 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH \
     RUST_VERSION=1.54.0
 
+RUN mv /usr/local/bin/openssl /root/backup/openssl/bin/openssl
+RUN mv /usr/local/ssl /root/backup/openssl/
 RUN update-ca-certificates
 
 RUN set -eux; \

--- a/docker/pravega.Dockerfile
+++ b/docker/pravega.Dockerfile
@@ -21,6 +21,7 @@ RUN ["/install-dependencies"]
 
 COPY docker/ca-certificates /usr/local/share/ca-certificates/
 RUN update-ca-certificates
+RUN ln -s /etc/ssl/certs/ca-certificates.crt  /usr/lib/ssl/cert.pem
 
 ARG GSTREAMER_REPOSITORY=https://gitlab.freedesktop.org/nazar-pc/gstreamer.git
 ARG GSTREAMER_CHECKOUT=master
@@ -74,6 +75,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     RUST_VERSION=1.54.0
 
 RUN update-ca-certificates
+RUN ln -s /etc/ssl/certs/ca-certificates.crt  /usr/lib/ssl/cert.pem
 
 RUN set -eux; \
     rustArch="x86_64-unknown-linux-gnu"; \

--- a/docker/pravega.Dockerfile
+++ b/docker/pravega.Dockerfile
@@ -21,7 +21,6 @@ RUN ["/install-dependencies"]
 
 COPY docker/ca-certificates /usr/local/share/ca-certificates/
 RUN update-ca-certificates
-RUN ln -s /etc/ssl/certs/ca-certificates.crt  /usr/lib/ssl/cert.pem
 
 ARG GSTREAMER_REPOSITORY=https://gitlab.freedesktop.org/nazar-pc/gstreamer.git
 ARG GSTREAMER_CHECKOUT=master
@@ -74,13 +73,10 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH \
     RUST_VERSION=1.54.0
 
-RUN ls -l /etc/ssl/certs/ca-certificates.crt
-RUN update-ca-certificates
-
 RUN set -eux; \
     rustArch="x86_64-unknown-linux-gnu"; \
     url="https://static.rust-lang.org/rustup/archive/1.23.1/${rustArch}/rustup-init"; \
-    wget --quiet --no-check-certificate "$url"; \
+    wget --quiet "$url"; \
     chmod +x rustup-init; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \

--- a/docker/pravega.Dockerfile
+++ b/docker/pravega.Dockerfile
@@ -74,7 +74,8 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH \
     RUST_VERSION=1.54.0
 
-RUN mv /usr/local/bin/openssl /root/backup/openssl/bin/openssl
+RUN ls -l /usr/lib/ssl/cert.pem
+
 RUN mv /usr/local/ssl /root/backup/openssl/
 RUN update-ca-certificates
 

--- a/docker/pravega.Dockerfile
+++ b/docker/pravega.Dockerfile
@@ -76,9 +76,8 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN set -eux; \
     rustArch="x86_64-unknown-linux-gnu"; \
     url="https://static.rust-lang.org/rustup/archive/1.23.1/${rustArch}/rustup-init"; \
-    wget --no-check-certificate "$url"
-
-RUN chmod +x rustup-init; \
+    wget --quiet --no-check-certificate "$url"; \
+    chmod +x rustup-init; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \

--- a/docker/pravega.Dockerfile
+++ b/docker/pravega.Dockerfile
@@ -74,9 +74,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH \
     RUST_VERSION=1.54.0
 
-RUN ls -l /usr/lib/ssl/cert.pem
-
-RUN mv /usr/local/ssl /root/backup/openssl/
+RUN ls -l /etc/ssl/certs/ca-certificates.crt
 RUN update-ca-certificates
 
 RUN set -eux; \

--- a/docker/pravega.Dockerfile
+++ b/docker/pravega.Dockerfile
@@ -76,7 +76,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN set -eux; \
     rustArch="x86_64-unknown-linux-gnu"; \
     url="https://static.rust-lang.org/rustup/archive/1.23.1/${rustArch}/rustup-init"; \
-    wget --ca-directory=/usr/local/share/ca-certificates/ "$url"
+    wget --no-check-certificate "$url"
 
 RUN chmod +x rustup-init; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION --default-host ${rustArch}; \

--- a/docker/pravega.Dockerfile
+++ b/docker/pravega.Dockerfile
@@ -73,6 +73,8 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH \
     RUST_VERSION=1.54.0
 
+RUN update-ca-certificates
+
 RUN set -eux; \
     rustArch="x86_64-unknown-linux-gnu"; \
     url="https://static.rust-lang.org/rustup/archive/1.23.1/${rustArch}/rustup-init"; \

--- a/docker/pravega.Dockerfile
+++ b/docker/pravega.Dockerfile
@@ -75,7 +75,6 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     RUST_VERSION=1.54.0
 
 RUN update-ca-certificates
-RUN ln -s /etc/ssl/certs/ca-certificates.crt  /usr/lib/ssl/cert.pem
 
 RUN set -eux; \
     rustArch="x86_64-unknown-linux-gnu"; \

--- a/gst-plugin-pravega/src/timestampcvt/imp.rs
+++ b/gst-plugin-pravega/src/timestampcvt/imp.rs
@@ -151,7 +151,7 @@ impl TimestampCvt {
         let pts_correction_delta = 15 * MSECOND;
 
         let input_pts = buffer.pts();
-        let input_dts = buffer.dts();
+        // let input_dts = buffer.dts();
         if input_pts.is_some() {
             let input_nanos = input_pts.nanoseconds().unwrap();
             // corrected_input_pts will be the TAI timestamp of the input buffer.

--- a/gst-plugin-pravega/src/timestampcvt/imp.rs
+++ b/gst-plugin-pravega/src/timestampcvt/imp.rs
@@ -218,12 +218,15 @@ impl TimestampCvt {
                     gst_log!(CAT, obj: pad, "Input PTS {}, Output PTS {:?}", input_pts, output_pts);                    
                     buffer_ref.set_pts(output_pts_clocktime);
 
+
+                    /*
                     // Adjust DTS if it exists by the nominal PTS offset.
                     if input_dts.is_some() && state.pts_offset_nanos.is_some() {
                         let output_dts = ClockTime::from_nseconds((input_dts.nanoseconds().unwrap() as i128 + state.pts_offset_nanos.unwrap()) as u64);
                         gst_log!(CAT, obj: pad, "Input DTS {}, Output DTS {:?}", input_dts, output_dts);
                         buffer_ref.set_dts(output_dts);
                     }
+                    */
 
                     self.srcpad.push(buffer)
                 }

--- a/gst-plugin-pravega/src/timestampcvt/imp.rs
+++ b/gst-plugin-pravega/src/timestampcvt/imp.rs
@@ -151,7 +151,7 @@ impl TimestampCvt {
         let pts_correction_delta = 15 * MSECOND;
 
         let input_pts = buffer.pts();
-        // let input_dts = buffer.dts();
+        let input_dts = buffer.dts();
         if input_pts.is_some() {
             let input_nanos = input_pts.nanoseconds().unwrap();
             // corrected_input_pts will be the TAI timestamp of the input buffer.
@@ -215,18 +215,15 @@ impl TimestampCvt {
                     state.prev_output_pts = output_pts;
                     let output_pts_clocktime = pravega_to_clocktime(output_pts);
                     let buffer_ref = buffer.make_mut();
-                    gst_log!(CAT, obj: pad, "Input PTS {}, Output PTS {:?}", input_pts, output_pts);                    
+                    gst_log!(CAT, obj: pad, "Input PTS {}, Output PTS {:?}", input_pts, output_pts);
                     buffer_ref.set_pts(output_pts_clocktime);
 
-
-                    /*
                     // Adjust DTS if it exists by the nominal PTS offset.
                     if input_dts.is_some() && state.pts_offset_nanos.is_some() {
                         let output_dts = ClockTime::from_nseconds((input_dts.nanoseconds().unwrap() as i128 + state.pts_offset_nanos.unwrap()) as u64);
                         gst_log!(CAT, obj: pad, "Input DTS {}, Output DTS {:?}", input_dts, output_dts);
                         buffer_ref.set_dts(output_dts);
                     }
-                    */
 
                     self.srcpad.push(buffer)
                 }

--- a/gst-plugin-pravega/tests/timestampcvt.rs
+++ b/gst-plugin-pravega/tests/timestampcvt.rs
@@ -20,7 +20,6 @@ fn init() {
 
     INIT.call_once(|| {
         gst::init().unwrap();
-        //gstpravega::plugin_register_static().unwrap();
     });
 }
 

--- a/gst-plugin-pravega/tests/timestampcvt.rs
+++ b/gst-plugin-pravega/tests/timestampcvt.rs
@@ -20,7 +20,7 @@ fn init() {
 
     INIT.call_once(|| {
         gst::init().unwrap();
-        gstpravega::plugin_register_static().unwrap();
+        //gstpravega::plugin_register_static().unwrap();
     });
 }
 


### PR DESCRIPTION
Updating the base image to `ubuntu:22.04` to get the latest security fixes:

- updated the base ubuntu image
- updated openssl-related rust dependencies
- updated prod dependencies to match the ones shipped with ubuntu:22.04
- updated the key to pull the deepstream image (as the key got rotated recently)
- fixed the integration test to work with the updated dependencies

Testing: integration tests passed
