### PR TITLE
Fix blue gap issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,7 +761,7 @@ The index must be reliable in the sense that if it has a {timestamp, offset} pai
 The index and related data stream must satisfy the following constraints.
 
 1. If the first record in the index has timestamp T1 and offset O1 (T1, O1),
-   and the last record in the index has timestamp TN and offset TN (TN, ON),
+   and the last record in the index has timestamp TN and offset ON (TN, ON),
    then the data stream can be read from offset O1 inclusive to ON exclusive.
    The bytes prior to O1 may have been truncated.
    All bytes between O1 and ON have been written to the Pravega server and,

--- a/apps/src/bin/pravega_event_dumper.rs
+++ b/apps/src/bin/pravega_event_dumper.rs
@@ -39,7 +39,7 @@ struct Opts {
     keycloak_file: String,
 }
 
-/// Demonstrate ability to write using the byte stream writer and read using the event reader.
+/// Dump the indexes and events for debug purpose
 fn main() {
     env_logger::init();
     let opts: Opts = Opts::parse();

--- a/apps/src/bin/pravega_event_dumper.rs
+++ b/apps/src/bin/pravega_event_dumper.rs
@@ -1,0 +1,67 @@
+//
+// Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+
+use clap::Clap;
+use log::info;
+use std::{thread, time};
+
+use pravega_client::client_factory::ClientFactory;
+use pravega_client_shared::{Scope, Stream, ScopedStream};
+
+use pravega_video::index::IndexSearcher;
+use pravega_video::utils;
+use pravega_video::utils::SyncByteReader;
+
+#[derive(Clap)]
+struct Opts {
+    /// Pravega controller in format "127.0.0.1:9090"
+    #[clap(short, long, default_value = "127.0.0.1:9090")]
+    controller: String,
+    /// Pravega scope
+    #[clap(long)]
+    scope: String,
+    /// Pravega stream
+    #[clap(long)]
+    stream: String,
+    /// Pravega keycloak file
+    #[clap(long, default_value = "", setting(clap::ArgSettings::AllowEmptyValues))]
+    keycloak_file: String,
+}
+
+/// Demonstrate ability to write using the byte stream writer and read using the event reader.
+fn main() {
+    env_logger::init();
+    let opts: Opts = Opts::parse();
+    let keycloak_file = if opts.keycloak_file.is_empty() {
+        None
+    } else {
+        Some(opts.keycloak_file)
+    };
+    let client_config = utils::create_client_config(opts.controller, keycloak_file).expect("creating config");
+    let client_factory = ClientFactory::new(client_config);
+    let scope = Scope::from(opts.scope);
+    let stream_name = format!("{}-index", opts.stream);
+    let stream = Stream::from(stream_name);
+    let index_scoped_stream = ScopedStream {
+        scope: scope,
+        stream: stream,
+    };
+    let runtime = client_factory.runtime();
+    let index_reader = runtime.block_on(client_factory.create_byte_reader(index_scoped_stream));
+    let mut index_searcher = IndexSearcher::new(SyncByteReader::new(index_reader, client_factory.runtime_handle()));
+
+    let first_record = index_searcher.get_first_record().unwrap();
+    info!("The first index record: timestamp={}", first_record.timestamp);
+    let last_record = index_searcher.get_last_record().unwrap();
+    info!("The last index record: timestamp={}", last_record.timestamp);
+    let size = last_record.offset - first_record.offset;
+    let size_in_mb = size / 1024 / 1024;
+    info!("Data size between the first index and last index is {} MB",  size_in_mb);
+}

--- a/gst-plugin-pravega/tests/timestampcvt.rs
+++ b/gst-plugin-pravega/tests/timestampcvt.rs
@@ -20,6 +20,7 @@ fn init() {
 
     INIT.call_once(|| {
         gst::init().unwrap();
+        gstpravega::plugin_register_static().unwrap();
     });
 }
 

--- a/pravega-video/src/event_serde.rs
+++ b/pravega-video/src/event_serde.rs
@@ -37,6 +37,7 @@ pub struct EventWithHeader<'a> {
     pub payload: &'a [u8],
 }
 
+/// ```text
 /**
    A struct to serialize an EventWithHeader for writing to a Pravega byte stream.
 
@@ -113,6 +114,7 @@ pub struct EventWithHeader<'a> {
       Writes of the entire frame (type code through payload) must be atomic,
       which means it must be 8 MiB or smaller.
 */
+/// ```
 pub struct EventWriter {
 }
 

--- a/pravega-video/src/index.rs
+++ b/pravega-video/src/index.rs
@@ -45,6 +45,7 @@ impl IndexRecord {
     }
 }
 
+/// ```text
 /**
    A struct to serialize an IndexRecord for writing to a Pravega byte stream.
 
@@ -104,6 +105,7 @@ impl IndexRecord {
    4. If index records 2 through N have DIS of 0, then it is guaranteed that
       the bytes between O1 and ON were written continuously.
 */
+/// ```
 pub struct IndexRecordWriter {
 }
 

--- a/scripts/pravega-event-dumper.sh
+++ b/scripts/pravega-event-dumper.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+
+set -ex
+ROOT_DIR=$(readlink -f $(dirname $0)/..)
+pushd ${ROOT_DIR}/apps
+cargo build
+popd
+
+export RUST_LOG=${RUST_LOG:-info}
+export RUST_BACKTRACE=1
+PRAVEGA_CONTROLLER_URI=${PRAVEGA_CONTROLLER_URI:-127.0.0.1:9090}
+PRAVEGA_SCOPE=${PRAVEGA_SCOPE:-examples}
+PRAVEGA_STREAM=${PRAVEGA_STREAM:-camera1}
+
+pushd ${ROOT_DIR}/apps
+cargo run --bin pravega_event_dumper -- \
+--controller ${PRAVEGA_CONTROLLER_URI} \
+--scope ${PRAVEGA_SCOPE} \
+--stream ${PRAVEGA_STREAM} \
+--keycloak-file "${KEYCLOAK_SERVICE_ACCOUNT_FILE}" \
+$* \
+|& tee /tmp/pravega-event-dumper.log
+popd

--- a/scripts/pravega-event-dumper.sh
+++ b/scripts/pravega-event-dumper.sh
@@ -16,7 +16,7 @@ pushd ${ROOT_DIR}/apps
 cargo build
 popd
 
-export RUST_LOG=${RUST_LOG:-info}
+#export RUST_LOG=${RUST_LOG:-info}
 export RUST_BACKTRACE=1
 PRAVEGA_CONTROLLER_URI=${PRAVEGA_CONTROLLER_URI:-127.0.0.1:9090}
 PRAVEGA_SCOPE=${PRAVEGA_SCOPE:-examples}
@@ -27,6 +27,8 @@ cargo run --bin pravega_event_dumper -- \
 --controller ${PRAVEGA_CONTROLLER_URI} \
 --scope ${PRAVEGA_SCOPE} \
 --stream ${PRAVEGA_STREAM} \
+--index-num 100 \
+--show-event \
 --keycloak-file "${KEYCLOAK_SERVICE_ACCOUNT_FILE}" \
 $* \
 |& tee /tmp/pravega-event-dumper.log


### PR DESCRIPTION
1. some gstreamer element like h264parse may add discont flag to I frames which would play blue gaps for now.
For indexes whose gap from last index are less than the target duration, simply ignore the discont flag before we could figure out why discont flag was set to mitigate the blue gap issue temporarily.
2. integration test could execute with latest rust binaries now